### PR TITLE
Car Ordering, Terminal Scratch, Item Accepting, Discarded Cards, and more :)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -5,7 +5,6 @@
     "serverIp": "127.0.0.1",
     "gameOptions": {
         "grantFullTuneTicketToNewUsers": 3, 
-        "grantBonusScratchCars": 0, 
         "giftCarsFullyTuned": 0, 
         "scratchEnabled": 1, 
         "scratchType": 1

--- a/config.example.json
+++ b/config.example.json
@@ -4,8 +4,10 @@
     "regionName": "Bayshore",
     "serverIp": "127.0.0.1",
     "gameOptions": {
-        "grantFullTuneTicketToNewUsers": 0,
-        "grantAllScratchRewards": 0, 
-        "grantBonusScratchCars": 0
+        "grantFullTuneTicketToNewUsers": 3, 
+        "grantBonusScratchCars": 0, 
+        "giftCarsFullyTuned": 0, 
+        "scratchEnabled": 1, 
+        "scratchType": 1
     }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,43 +11,46 @@ datasource db {
 }
 
 model User {
-  id            Int        @id @default(autoincrement())
-  chipId        String     @unique
+  id            Int            @id @default(autoincrement())
+  chipId        String         @unique
   accessCode    String
   cars          Car[]
-  carOrder      Int[] // Order of cars
-  unusedTickets UserItem[]
+  carOrder      Int[]
+  items         UserItem[]
   tutorials     Boolean[]
-  userBanned    Boolean    @default(false)
+  userBanned    Boolean        @default(false)
   bookmarks     Int[]
-  // ScratchSheet  ScratchSheet[]
-  currentSheet  Int        @default(0)
-  lastSheet     Int        @default(0)
+  ScratchSheet  ScratchSheet[]
+  currentSheet  Int            @default(1)
+  lastSheet     Int            @default(1)
+  lastScratched Int            @default(0) // Timestamp
 }
 
-// Not working yet, removing from schema
-// model ScratchSheet {
-//   id      Int             @id @default(autoincrement())
-//   User    User            @relation(fields: [userId], references: [id])
-//   userId  Int             @unique
-//   squares ScratchSquare[]
-// }
+model ScratchSheet {
+  id      Int             @id @default(autoincrement())
+  User    User            @relation(fields: [userId], references: [id])
+  userId  Int
+  sheetNo Int // Player's sheet number (i.e. first sheet)
+  squares ScratchSquare[]
+}
 
-// model ScratchSquare {
-//   id       Int          @id @default(autoincrement())
-//   Sheet    ScratchSheet @relation(fields: [sheetId], references: [id])
-//   sheetId  Int
-//   category Int
-//   itemId   Int
-//   earned   Boolean
-// }
-
-model UserItem {
-  dbId     Int  @id @default(autoincrement())
+model ScratchSquare {
+  id       Int          @id @default(autoincrement())
+  Sheet    ScratchSheet @relation(fields: [sheetId], references: [id])
+  sheetId  Int
   category Int
   itemId   Int
-  User     User @relation(fields: [userId], references: [id])
-  userId   Int
+  earned   Boolean
+}
+
+model UserItem {
+  userItemId Int  @id @default(autoincrement())
+  category   Int
+  itemId     Int
+  User       User @relation(fields: [userId], references: [id])
+  userId     Int
+  type       Int  @default(0)
+  earnedAt   Int  @default(0)
 }
 
 model Car {
@@ -82,6 +85,7 @@ model Car {
   windowStickerString String  @default("ＷＡＮＧＡＮ")
   windowStickerFont   Int     @default(0)
   rivalMarker         Int     @default(0)
+  lastPlayedAt        Int     @default(0)
   aura                Int     @default(0)
   auraMotif           Int     @default(0)
   ghostLevel          Int     @default(1)
@@ -127,9 +131,9 @@ model Car {
 }
 
 model CarItem {
-  Car   Car? @relation(fields: [carId], references: [carId])
-  carId Int  @unique
-
+  dbId     Int @id @default(autoincrement())
+  Car      Car @relation(fields: [carId], references: [carId])
+  carId    Int
   category Int
   itemId   Int
   amount   Int

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,186 +2,186 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-    provider = "prisma-client-js"
+  provider = "prisma-client-js"
 }
 
 datasource db {
-    provider = "postgresql"
-    url      = env("POSTGRES_URL")
+  provider = "postgresql"
+  url      = env("POSTGRES_URL")
 }
 
 model User {
-    id            Int            @id @default(autoincrement())
-    chipId        String         @unique
-    accessCode    String
-    cars          Car[]
-    carOrder      Int[]
-    items         UserItem[]
-    tutorials     Boolean[]
-    userBanned    Boolean        @default(false)
-    bookmarks     Int[]
-    ScratchSheet  ScratchSheet[]
-    currentSheet  Int            @default(1)
-    lastScratched Int            @default(0) // Timestamp
+  id            Int            @id @default(autoincrement())
+  chipId        String         @unique
+  accessCode    String
+  cars          Car[]
+  carOrder      Int[]
+  items         UserItem[]
+  tutorials     Boolean[]
+  userBanned    Boolean        @default(false)
+  bookmarks     Int[]
+  ScratchSheet  ScratchSheet[]
+  currentSheet  Int            @default(1)
+  lastScratched Int            @default(0) // Timestamp
 }
 
 model ScratchSheet {
-    id      Int             @id @default(autoincrement())
-    User    User            @relation(fields: [userId], references: [id])
-    userId  Int
-    sheetNo Int // Player's sheet number (i.e. first sheet)
-    squares ScratchSquare[]
+  id      Int             @id @default(autoincrement())
+  User    User            @relation(fields: [userId], references: [id])
+  userId  Int
+  sheetNo Int // Player's sheet number (i.e. first sheet)
+  squares ScratchSquare[]
 }
 
 model ScratchSquare {
-    id       Int          @id @default(autoincrement())
-    Sheet    ScratchSheet @relation(fields: [sheetId], references: [id])
-    sheetId  Int
-    category Int
-    itemId   Int
-    earned   Boolean
+  id       Int          @id @default(autoincrement())
+  Sheet    ScratchSheet @relation(fields: [sheetId], references: [id])
+  sheetId  Int
+  category Int
+  itemId   Int
+  earned   Boolean
 }
 
 model UserItem {
-    userItemId Int  @id @default(autoincrement())
-    category   Int
-    itemId     Int
-    User       User @relation(fields: [userId], references: [id])
-    userId     Int
-    type       Int  @default(0)
-    earnedAt   Int  @default(0)
+  userItemId Int  @id @default(autoincrement())
+  category   Int
+  itemId     Int
+  User       User @relation(fields: [userId], references: [id])
+  userId     Int
+  type       Int  @default(0)
+  earnedAt   Int  @default(0)
 }
 
 model Car {
-    user   User @relation(fields: [userId], references: [id])
-    userId Int
+  user   User @relation(fields: [userId], references: [id])
+  userId Int
 
-    // This is the Car object itself
-    carId               Int     @id @default(autoincrement())
-    name                String
-    manufacturer        Int
-    regionId            Int     @default(0)
-    model               Int
-    visualModel         Int
-    customColor         Int     @default(0)
-    defaultColor        Int
-    wheel               Int     @default(0)
-    wheelColor          Int     @default(0)
-    aero                Int     @default(0)
-    bonnet              Int     @default(0)
-    wing                Int     @default(0)
-    mirror              Int     @default(0)
-    neon                Int     @default(0)
-    trunk               Int     @default(0)
-    plate               Int     @default(0)
-    plateColor          Int     @default(0)
-    plateNumber         Int     @default(0)
-    tunePower           Int     @default(0)
-    tuneHandling        Int     @default(0)
-    title               String  @default("New Car")
-    level               Int     @default(0)
-    windowSticker       Boolean @default(false)
-    windowStickerString String  @default("ＷＡＮＧＡＮ")
-    windowStickerFont   Int     @default(0)
-    rivalMarker         Int     @default(0)
-    lastPlayedAt        Int     @default(0)
-    aura                Int     @default(0)
-    auraMotif           Int     @default(0)
-    ghostLevel          Int     @default(1)
+  // This is the Car object itself
+  carId               Int     @id @default(autoincrement())
+  name                String
+  manufacturer        Int
+  regionId            Int     @default(0)
+  model               Int
+  visualModel         Int
+  customColor         Int     @default(0)
+  defaultColor        Int
+  wheel               Int     @default(0)
+  wheelColor          Int     @default(0)
+  aero                Int     @default(0)
+  bonnet              Int     @default(0)
+  wing                Int     @default(0)
+  mirror              Int     @default(0)
+  neon                Int     @default(0)
+  trunk               Int     @default(0)
+  plate               Int     @default(0)
+  plateColor          Int     @default(0)
+  plateNumber         Int     @default(0)
+  tunePower           Int     @default(0)
+  tuneHandling        Int     @default(0)
+  title               String  @default("New Car")
+  level               Int     @default(0)
+  windowSticker       Boolean @default(false)
+  windowStickerString String  @default("ＷＡＮＧＡＮ")
+  windowStickerFont   Int     @default(0)
+  rivalMarker         Int     @default(0)
+  lastPlayedAt        Int     @default(0)
+  aura                Int     @default(0)
+  auraMotif           Int     @default(0)
+  ghostLevel          Int     @default(1)
 
-    // This is more data about the car
-    tuningPoints           Int         @default(0)
-    odometer               Int         @default(0)
-    playCount              Int         @default(0)
-    earnedCustomColor      Boolean     @default(false)
-    carSettingsDbId        Int         @unique
-    settings               CarSettings @relation(fields: [carSettingsDbId], references: [dbId])
-    vsPlayCount            Int         @default(0)
-    vsBurstCount           Int         @default(0)
-    vsStarCount            Int         @default(0)
-    vsCoolOrWild           Int         @default(0)
-    vsSmoothOrRough        Int         @default(0)
-    vsTripleStarMedals     Int         @default(0)
-    vsDoubleStarMedals     Int         @default(0)
-    vsSingleStarMedals     Int         @default(0)
-    vsPlainMedals          Int         @default(0)
-    rgPlayCount            Int         @default(0)
-    rgWinCount             Int         @default(0)
-    rgTrophy               Int         @default(0)
-    rgScore                Int         @default(0)
-    rgStamp                Int         @default(0)
-    rgAcquireAllCrowns     Boolean     @default(false)
-    rgRegionMapScore       Int[]
-    dressupLevel           Int         @default(0)
-    dressupPoint           Int         @default(0)
-    stPlayCount            Int         @default(0)
-    stClearBits            Int         @default(0)
-    stClearDivCount        Int         @default(0)
-    stClearCount           Int         @default(0)
-    stLoseBits             BigInt      @default(0)
-    stConsecutiveWins      Int         @default(0)
-    stConsecutiveWinsMax   Int         @default(0)
-    stCompleted100Episodes Boolean     @default(false)
+  // This is more data about the car
+  tuningPoints           Int         @default(0)
+  odometer               Int         @default(0)
+  playCount              Int         @default(0)
+  earnedCustomColor      Boolean     @default(false)
+  carSettingsDbId        Int         @unique
+  settings               CarSettings @relation(fields: [carSettingsDbId], references: [dbId])
+  vsPlayCount            Int         @default(0)
+  vsBurstCount           Int         @default(0)
+  vsStarCount            Int         @default(0)
+  vsCoolOrWild           Int         @default(0)
+  vsSmoothOrRough        Int         @default(0)
+  vsTripleStarMedals     Int         @default(0)
+  vsDoubleStarMedals     Int         @default(0)
+  vsSingleStarMedals     Int         @default(0)
+  vsPlainMedals          Int         @default(0)
+  rgPlayCount            Int         @default(0)
+  rgWinCount             Int         @default(0)
+  rgTrophy               Int         @default(0)
+  rgScore                Int         @default(0)
+  rgStamp                Int         @default(0)
+  rgAcquireAllCrowns     Boolean     @default(false)
+  rgRegionMapScore       Int[]
+  dressupLevel           Int         @default(0)
+  dressupPoint           Int         @default(0)
+  stPlayCount            Int         @default(0)
+  stClearBits            Int         @default(0)
+  stClearDivCount        Int         @default(0)
+  stClearCount           Int         @default(0)
+  stLoseBits             BigInt      @default(0)
+  stConsecutiveWins      Int         @default(0)
+  stConsecutiveWinsMax   Int         @default(0)
+  stCompleted100Episodes Boolean     @default(false)
 
-    items CarItem[]
+  items CarItem[]
 
-    carStateDbId     Int                @unique
-    state            CarState           @relation(fields: [carStateDbId], references: [dbId])
-    TimeAttackRecord TimeAttackRecord[]
+  carStateDbId     Int                @unique
+  state            CarState           @relation(fields: [carStateDbId], references: [dbId])
+  TimeAttackRecord TimeAttackRecord[]
 }
 
 model CarItem {
-    dbId     Int @id @default(autoincrement())
-    Car      Car @relation(fields: [carId], references: [carId])
-    carId    Int
-    category Int
-    itemId   Int
-    amount   Int
+  dbId     Int @id @default(autoincrement())
+  Car      Car @relation(fields: [carId], references: [carId])
+  carId    Int
+  category Int
+  itemId   Int
+  amount   Int
 }
 
 model CarSettings {
-    dbId Int  @id @default(autoincrement())
-    car  Car?
+  dbId Int  @id @default(autoincrement())
+  car  Car?
 
-    view               Boolean @default(true)
-    transmission       Boolean @default(false)
-    retire             Boolean @default(false)
-    meter              Int     @default(0)
-    navigationMap      Boolean @default(true)
-    volume             Int     @default(1)
-    bgm                Int     @default(0)
-    nameplate          Int     @default(0)
-    nameplateColor     Int     @default(0)
-    terminalBackground Int     @default(0)
+  view               Boolean @default(true)
+  transmission       Boolean @default(false)
+  retire             Boolean @default(false)
+  meter              Int     @default(0)
+  navigationMap      Boolean @default(true)
+  volume             Int     @default(1)
+  bgm                Int     @default(0)
+  nameplate          Int     @default(0)
+  nameplateColor     Int     @default(0)
+  terminalBackground Int     @default(0)
 }
 
 model CarState {
-    dbId Int  @id @default(autoincrement())
-    car  Car?
+  dbId Int  @id @default(autoincrement())
+  car  Car?
 
-    hasOpponentGhost Boolean @default(false)
-    eventJoined      Boolean @default(false)
-    transferred      Boolean @default(false)
-    toBeDeleted      Boolean @default(false)
+  hasOpponentGhost Boolean @default(false)
+  eventJoined      Boolean @default(false)
+  transferred      Boolean @default(false)
+  toBeDeleted      Boolean @default(false)
 }
 
 model TimeAttackRecord {
-    dbId Int @id @default(autoincrement())
+  dbId Int @id @default(autoincrement())
 
-    car   Car @relation(fields: [carId], references: [carId])
-    carId Int
+  car   Car @relation(fields: [carId], references: [carId])
+  carId Int
 
-    model        Int // Car model, literally just the `model` field from Car
-    time         Int
-    course       Int
-    isMorning    Boolean
-    section1Time Int     @map("section1Time")
-    section2Time Int     @map("section2Time")
-    section3Time Int     @map("section3Time")
-    section4Time Int     @map("section4Time")
-    section5Time Int?    @map("section5Time")
-    section6Time Int?    @map("section6Time")
-    section7Time Int?    @map("section7Time")
-    tunePower    Int     @default(0) // Car Power
-    tuneHandling Int     @default(0) // Car Handling
+  model        Int // Car model, literally just the `model` field from Car
+  time         Int
+  course       Int
+  isMorning    Boolean
+  section1Time Int     @map("section1Time")
+  section2Time Int     @map("section2Time")
+  section3Time Int     @map("section3Time")
+  section4Time Int     @map("section4Time")
+  section5Time Int?    @map("section5Time")
+  section6Time Int?    @map("section6Time")
+  section7Time Int?    @map("section7Time")
+  tunePower    Int     @default(0) // Car Power
+  tuneHandling Int     @default(0) // Car Handling
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,186 +2,186 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
+    provider = "prisma-client-js"
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("POSTGRES_URL")
+    provider = "postgresql"
+    url      = env("POSTGRES_URL")
 }
 
 model User {
-  id            Int            @id @default(autoincrement())
-  chipId        String         @unique
-  accessCode    String
-  cars          Car[]
-  carOrder      Int[]
-  items         UserItem[]
-  tutorials     Boolean[]
-  userBanned    Boolean        @default(false)
-  bookmarks     Int[]
-  ScratchSheet  ScratchSheet[]
-  currentSheet  Int            @default(1)
-  lastScratched Int            @default(0) // Timestamp
+    id            Int            @id @default(autoincrement())
+    chipId        String         @unique
+    accessCode    String
+    cars          Car[]
+    carOrder      Int[]
+    items         UserItem[]
+    tutorials     Boolean[]
+    userBanned    Boolean        @default(false)
+    bookmarks     Int[]
+    ScratchSheet  ScratchSheet[]
+    currentSheet  Int            @default(1)
+    lastScratched Int            @default(0) // Timestamp
 }
 
 model ScratchSheet {
-  id      Int             @id @default(autoincrement())
-  User    User            @relation(fields: [userId], references: [id])
-  userId  Int
-  sheetNo Int // Player's sheet number (i.e. first sheet)
-  squares ScratchSquare[]
+    id      Int             @id @default(autoincrement())
+    User    User            @relation(fields: [userId], references: [id])
+    userId  Int
+    sheetNo Int // Player's sheet number (i.e. first sheet)
+    squares ScratchSquare[]
 }
 
 model ScratchSquare {
-  id       Int          @id @default(autoincrement())
-  Sheet    ScratchSheet @relation(fields: [sheetId], references: [id])
-  sheetId  Int
-  category Int
-  itemId   Int
-  earned   Boolean
+    id       Int          @id @default(autoincrement())
+    Sheet    ScratchSheet @relation(fields: [sheetId], references: [id])
+    sheetId  Int
+    category Int
+    itemId   Int
+    earned   Boolean
 }
 
 model UserItem {
-  userItemId Int  @id @default(autoincrement())
-  category   Int
-  itemId     Int
-  User       User @relation(fields: [userId], references: [id])
-  userId     Int
-  type       Int  @default(0)
-  earnedAt   Int  @default(0)
+    userItemId Int  @id @default(autoincrement())
+    category   Int
+    itemId     Int
+    User       User @relation(fields: [userId], references: [id])
+    userId     Int
+    type       Int  @default(0)
+    earnedAt   Int  @default(0)
 }
 
 model Car {
-  user   User @relation(fields: [userId], references: [id])
-  userId Int
+    user   User @relation(fields: [userId], references: [id])
+    userId Int
 
-  // This is the Car object itself
-  carId               Int     @id @default(autoincrement())
-  name                String
-  manufacturer        Int
-  regionId            Int     @default(0)
-  model               Int
-  visualModel         Int
-  customColor         Int     @default(0)
-  defaultColor        Int
-  wheel               Int     @default(0)
-  wheelColor          Int     @default(0)
-  aero                Int     @default(0)
-  bonnet              Int     @default(0)
-  wing                Int     @default(0)
-  mirror              Int     @default(0)
-  neon                Int     @default(0)
-  trunk               Int     @default(0)
-  plate               Int     @default(0)
-  plateColor          Int     @default(0)
-  plateNumber         Int     @default(0)
-  tunePower           Int     @default(0)
-  tuneHandling        Int     @default(0)
-  title               String  @default("New Car")
-  level               Int     @default(0)
-  windowSticker       Boolean @default(false)
-  windowStickerString String  @default("ＷＡＮＧＡＮ")
-  windowStickerFont   Int     @default(0)
-  rivalMarker         Int     @default(0)
-  lastPlayedAt        Int     @default(0)
-  aura                Int     @default(0)
-  auraMotif           Int     @default(0)
-  ghostLevel          Int     @default(1)
+    // This is the Car object itself
+    carId               Int     @id @default(autoincrement())
+    name                String
+    manufacturer        Int
+    regionId            Int     @default(0)
+    model               Int
+    visualModel         Int
+    customColor         Int     @default(0)
+    defaultColor        Int
+    wheel               Int     @default(0)
+    wheelColor          Int     @default(0)
+    aero                Int     @default(0)
+    bonnet              Int     @default(0)
+    wing                Int     @default(0)
+    mirror              Int     @default(0)
+    neon                Int     @default(0)
+    trunk               Int     @default(0)
+    plate               Int     @default(0)
+    plateColor          Int     @default(0)
+    plateNumber         Int     @default(0)
+    tunePower           Int     @default(0)
+    tuneHandling        Int     @default(0)
+    title               String  @default("New Car")
+    level               Int     @default(0)
+    windowSticker       Boolean @default(false)
+    windowStickerString String  @default("ＷＡＮＧＡＮ")
+    windowStickerFont   Int     @default(0)
+    rivalMarker         Int     @default(0)
+    lastPlayedAt        Int     @default(0)
+    aura                Int     @default(0)
+    auraMotif           Int     @default(0)
+    ghostLevel          Int     @default(1)
 
-  // This is more data about the car
-  tuningPoints           Int         @default(0)
-  odometer               Int         @default(0)
-  playCount              Int         @default(0)
-  earnedCustomColor      Boolean     @default(false)
-  carSettingsDbId        Int         @unique
-  settings               CarSettings @relation(fields: [carSettingsDbId], references: [dbId])
-  vsPlayCount            Int         @default(0)
-  vsBurstCount           Int         @default(0)
-  vsStarCount            Int         @default(0)
-  vsCoolOrWild           Int         @default(0)
-  vsSmoothOrRough        Int         @default(0)
-  vsTripleStarMedals     Int         @default(0)
-  vsDoubleStarMedals     Int         @default(0)
-  vsSingleStarMedals     Int         @default(0)
-  vsPlainMedals          Int         @default(0)
-  rgPlayCount            Int         @default(0)
-  rgWinCount             Int         @default(0)
-  rgTrophy               Int         @default(0)
-  rgScore                Int         @default(0)
-  rgStamp                Int         @default(0)
-  rgAcquireAllCrowns     Boolean     @default(false)
-  rgRegionMapScore       Int[]
-  dressupLevel           Int         @default(0)
-  dressupPoint           Int         @default(0)
-  stPlayCount            Int         @default(0)
-  stClearBits            Int         @default(0)
-  stClearDivCount        Int         @default(0)
-  stClearCount           Int         @default(0)
-  stLoseBits             BigInt      @default(0)
-  stConsecutiveWins      Int         @default(0)
-  stConsecutiveWinsMax   Int         @default(0)
-  stCompleted100Episodes Boolean     @default(false)
+    // This is more data about the car
+    tuningPoints           Int         @default(0)
+    odometer               Int         @default(0)
+    playCount              Int         @default(0)
+    earnedCustomColor      Boolean     @default(false)
+    carSettingsDbId        Int         @unique
+    settings               CarSettings @relation(fields: [carSettingsDbId], references: [dbId])
+    vsPlayCount            Int         @default(0)
+    vsBurstCount           Int         @default(0)
+    vsStarCount            Int         @default(0)
+    vsCoolOrWild           Int         @default(0)
+    vsSmoothOrRough        Int         @default(0)
+    vsTripleStarMedals     Int         @default(0)
+    vsDoubleStarMedals     Int         @default(0)
+    vsSingleStarMedals     Int         @default(0)
+    vsPlainMedals          Int         @default(0)
+    rgPlayCount            Int         @default(0)
+    rgWinCount             Int         @default(0)
+    rgTrophy               Int         @default(0)
+    rgScore                Int         @default(0)
+    rgStamp                Int         @default(0)
+    rgAcquireAllCrowns     Boolean     @default(false)
+    rgRegionMapScore       Int[]
+    dressupLevel           Int         @default(0)
+    dressupPoint           Int         @default(0)
+    stPlayCount            Int         @default(0)
+    stClearBits            Int         @default(0)
+    stClearDivCount        Int         @default(0)
+    stClearCount           Int         @default(0)
+    stLoseBits             BigInt      @default(0)
+    stConsecutiveWins      Int         @default(0)
+    stConsecutiveWinsMax   Int         @default(0)
+    stCompleted100Episodes Boolean     @default(false)
 
-  items CarItem[]
+    items CarItem[]
 
-  carStateDbId     Int                @unique
-  state            CarState           @relation(fields: [carStateDbId], references: [dbId])
-  TimeAttackRecord TimeAttackRecord[]
+    carStateDbId     Int                @unique
+    state            CarState           @relation(fields: [carStateDbId], references: [dbId])
+    TimeAttackRecord TimeAttackRecord[]
 }
 
 model CarItem {
-  dbId     Int @id @default(autoincrement())
-  Car      Car @relation(fields: [carId], references: [carId])
-  carId    Int
-  category Int
-  itemId   Int
-  amount   Int
+    dbId     Int @id @default(autoincrement())
+    Car      Car @relation(fields: [carId], references: [carId])
+    carId    Int
+    category Int
+    itemId   Int
+    amount   Int
 }
 
 model CarSettings {
-  dbId Int  @id @default(autoincrement())
-  car  Car?
+    dbId Int  @id @default(autoincrement())
+    car  Car?
 
-  view               Boolean @default(true)
-  transmission       Boolean @default(false)
-  retire             Boolean @default(false)
-  meter              Int     @default(0)
-  navigationMap      Boolean @default(true)
-  volume             Int     @default(1)
-  bgm                Int     @default(0)
-  nameplate          Int     @default(0)
-  nameplateColor     Int     @default(0)
-  terminalBackground Int     @default(0)
+    view               Boolean @default(true)
+    transmission       Boolean @default(false)
+    retire             Boolean @default(false)
+    meter              Int     @default(0)
+    navigationMap      Boolean @default(true)
+    volume             Int     @default(1)
+    bgm                Int     @default(0)
+    nameplate          Int     @default(0)
+    nameplateColor     Int     @default(0)
+    terminalBackground Int     @default(0)
 }
 
 model CarState {
-  dbId Int  @id @default(autoincrement())
-  car  Car?
+    dbId Int  @id @default(autoincrement())
+    car  Car?
 
-  hasOpponentGhost Boolean @default(false)
-  eventJoined      Boolean @default(false)
-  transferred      Boolean @default(false)
-  toBeDeleted      Boolean @default(false)
+    hasOpponentGhost Boolean @default(false)
+    eventJoined      Boolean @default(false)
+    transferred      Boolean @default(false)
+    toBeDeleted      Boolean @default(false)
 }
 
 model TimeAttackRecord {
-  dbId Int @id @default(autoincrement())
+    dbId Int @id @default(autoincrement())
 
-  car   Car @relation(fields: [carId], references: [carId])
-  carId Int
+    car   Car @relation(fields: [carId], references: [carId])
+    carId Int
 
-  model        Int // Car model, literally just the `model` field from Car
-  time         Int
-  course       Int
-  isMorning    Boolean
-  section1Time Int     @map("section1Time")
-  section2Time Int     @map("section2Time")
-  section3Time Int     @map("section3Time")
-  section4Time Int     @map("section4Time")
-  section5Time Int?    @map("section5Time")
-  section6Time Int?    @map("section6Time")
-  section7Time Int?    @map("section7Time")
-  tunePower    Int     @default(0) // Car Power
-  tuneHandling Int     @default(0) // Car Handling
+    model        Int // Car model, literally just the `model` field from Car
+    time         Int
+    course       Int
+    isMorning    Boolean
+    section1Time Int     @map("section1Time")
+    section2Time Int     @map("section2Time")
+    section3Time Int     @map("section3Time")
+    section4Time Int     @map("section4Time")
+    section5Time Int?    @map("section5Time")
+    section6Time Int?    @map("section6Time")
+    section7Time Int?    @map("section7Time")
+    tunePower    Int     @default(0) // Car Power
+    tuneHandling Int     @default(0) // Car Handling
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,35 +11,36 @@ datasource db {
 }
 
 model User {
-  id            Int            @id @default(autoincrement())
-  chipId        String         @unique
+  id            Int        @id @default(autoincrement())
+  chipId        String     @unique
   accessCode    String
   cars          Car[]
   carOrder      Int[] // Order of cars
   unusedTickets UserItem[]
   tutorials     Boolean[]
-  userBanned    Boolean        @default(false)
+  userBanned    Boolean    @default(false)
   bookmarks     Int[]
-  ScratchSheet  ScratchSheet[]
-  currentSheet  Int            @default(0)
-  lastSheet     Int            @default(0)
+  // ScratchSheet  ScratchSheet[]
+  currentSheet  Int        @default(0)
+  lastSheet     Int        @default(0)
 }
 
-model ScratchSheet {
-  id      Int             @id @default(autoincrement())
-  User    User            @relation(fields: [userId], references: [id])
-  userId  Int             @unique
-  squares ScratchSquare[]
-}
+// Not working yet, removing from schema
+// model ScratchSheet {
+//   id      Int             @id @default(autoincrement())
+//   User    User            @relation(fields: [userId], references: [id])
+//   userId  Int             @unique
+//   squares ScratchSquare[]
+// }
 
-model ScratchSquare {
-  id       Int          @id @default(autoincrement())
-  Sheet    ScratchSheet @relation(fields: [sheetId], references: [id])
-  sheetId  Int
-  category Int
-  itemId   Int
-  earned   Boolean
-}
+// model ScratchSquare {
+//   id       Int          @id @default(autoincrement())
+//   Sheet    ScratchSheet @relation(fields: [sheetId], references: [id])
+//   sheetId  Int
+//   category Int
+//   itemId   Int
+//   earned   Boolean
+// }
 
 model UserItem {
   dbId     Int  @id @default(autoincrement())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,186 +2,186 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-    provider = "prisma-client-js"
+  provider = "prisma-client-js"
 }
 
 datasource db {
-    provider = "postgresql"
-    url      = env("POSTGRES_URL")
+  provider = "postgresql"
+  url      = env("POSTGRES_URL")
 }
 
 model User {
-    id            Int            @id @default(autoincrement())
-    chipId        String         @unique
-    accessCode    String
-    cars          Car[]
-    carOrder      Int[]
-    items         UserItem[]
-    tutorials     Boolean[]
-    userBanned    Boolean        @default(false)
-    bookmarks     Int[]
-    ScratchSheet  ScratchSheet[]
-    currentSheet  Int            @default(1)
-    lastSheet     Int            @default(1)
-    lastScratched Int            @default(0) // Timestamp
+  id            Int            @id @default(autoincrement())
+  chipId        String         @unique
+  accessCode    String
+  cars          Car[]
+  carOrder      Int[]
+  items         UserItem[]
+  tutorials     Boolean[]
+  userBanned    Boolean        @default(false)
+  bookmarks     Int[]
+  ScratchSheet  ScratchSheet[]
+  currentSheet  Int            @default(1)
+  lastScratched Int            @default(0) // Timestamp
 }
 
 model ScratchSheet {
-    id      Int             @id @default(autoincrement())
-    User    User            @relation(fields: [userId], references: [id])
-    userId  Int
-    sheetNo Int // Player's sheet number (i.e. first sheet)
-    squares ScratchSquare[]
+  id      Int             @id @default(autoincrement())
+  User    User            @relation(fields: [userId], references: [id])
+  userId  Int
+  sheetNo Int // Player's sheet number (i.e. first sheet)
+  squares ScratchSquare[]
 }
 
 model ScratchSquare {
-    id       Int          @id @default(autoincrement())
-    Sheet    ScratchSheet @relation(fields: [sheetId], references: [id])
-    sheetId  Int
-    category Int
-    itemId   Int
-    earned   Boolean
+  id       Int          @id @default(autoincrement())
+  Sheet    ScratchSheet @relation(fields: [sheetId], references: [id])
+  sheetId  Int
+  category Int
+  itemId   Int
+  earned   Boolean
 }
 
 model UserItem {
-    userItemId Int  @id @default(autoincrement())
-    category   Int
-    itemId     Int
-    User       User @relation(fields: [userId], references: [id])
-    userId     Int
-    type       Int  @default(0)
-    earnedAt   Int  @default(0)
+  userItemId Int  @id @default(autoincrement())
+  category   Int
+  itemId     Int
+  User       User @relation(fields: [userId], references: [id])
+  userId     Int
+  type       Int  @default(0)
+  earnedAt   Int  @default(0)
 }
 
 model Car {
-    user   User @relation(fields: [userId], references: [id])
-    userId Int
+  user   User @relation(fields: [userId], references: [id])
+  userId Int
 
-    // This is the Car object itself
-    carId               Int     @id @default(autoincrement())
-    name                String
-    manufacturer        Int
-    regionId            Int     @default(0)
-    model               Int
-    visualModel         Int
-    customColor         Int     @default(0)
-    defaultColor        Int
-    wheel               Int     @default(0)
-    wheelColor          Int     @default(0)
-    aero                Int     @default(0)
-    bonnet              Int     @default(0)
-    wing                Int     @default(0)
-    mirror              Int     @default(0)
-    neon                Int     @default(0)
-    trunk               Int     @default(0)
-    plate               Int     @default(0)
-    plateColor          Int     @default(0)
-    plateNumber         Int     @default(0)
-    tunePower           Int     @default(0)
-    tuneHandling        Int     @default(0)
-    title               String  @default("New Car")
-    level               Int     @default(0)
-    windowSticker       Boolean @default(false)
-    windowStickerString String  @default("ＷＡＮＧＡＮ")
-    windowStickerFont   Int     @default(0)
-    rivalMarker         Int     @default(0)
-    lastPlayedAt        Int     @default(0)
-    aura                Int     @default(0)
-    auraMotif           Int     @default(0)
-    ghostLevel          Int     @default(1)
+  // This is the Car object itself
+  carId               Int     @id @default(autoincrement())
+  name                String
+  manufacturer        Int
+  regionId            Int     @default(0)
+  model               Int
+  visualModel         Int
+  customColor         Int     @default(0)
+  defaultColor        Int
+  wheel               Int     @default(0)
+  wheelColor          Int     @default(0)
+  aero                Int     @default(0)
+  bonnet              Int     @default(0)
+  wing                Int     @default(0)
+  mirror              Int     @default(0)
+  neon                Int     @default(0)
+  trunk               Int     @default(0)
+  plate               Int     @default(0)
+  plateColor          Int     @default(0)
+  plateNumber         Int     @default(0)
+  tunePower           Int     @default(0)
+  tuneHandling        Int     @default(0)
+  title               String  @default("New Car")
+  level               Int     @default(0)
+  windowSticker       Boolean @default(false)
+  windowStickerString String  @default("ＷＡＮＧＡＮ")
+  windowStickerFont   Int     @default(0)
+  rivalMarker         Int     @default(0)
+  lastPlayedAt        Int     @default(0)
+  aura                Int     @default(0)
+  auraMotif           Int     @default(0)
+  ghostLevel          Int     @default(1)
 
-    // This is more data about the car
-    tuningPoints           Int         @default(0)
-    odometer               Int         @default(0)
-    playCount              Int         @default(0)
-    earnedCustomColor      Boolean     @default(false)
-    carSettingsDbId        Int         @unique
-    settings               CarSettings @relation(fields: [carSettingsDbId], references: [dbId])
-    vsPlayCount            Int         @default(0)
-    vsBurstCount           Int         @default(0)
-    vsStarCount            Int         @default(0)
-    vsCoolOrWild           Int         @default(0)
-    vsSmoothOrRough        Int         @default(0)
-    vsTripleStarMedals     Int         @default(0)
-    vsDoubleStarMedals     Int         @default(0)
-    vsSingleStarMedals     Int         @default(0)
-    vsPlainMedals          Int         @default(0)
-    rgPlayCount            Int         @default(0)
-    rgWinCount             Int         @default(0)
-    rgTrophy               Int         @default(0)
-    rgScore                Int         @default(0)
-    rgStamp                Int         @default(0)
-    rgAcquireAllCrowns     Boolean     @default(false)
-    dressupLevel           Int         @default(0)
-    dressupPoint           Int         @default(0)
-    stPlayCount            Int         @default(0)
-    stClearBits            Int         @default(0)
-    stClearDivCount        Int         @default(0)
-    stClearCount           Int         @default(0)
-    stLoseBits             BigInt      @default(0)
-    stConsecutiveWins      Int         @default(0)
-    stConsecutiveWinsMax   Int         @default(0)
-    stCompleted100Episodes Boolean     @default(false)
+  // This is more data about the car
+  tuningPoints           Int         @default(0)
+  odometer               Int         @default(0)
+  playCount              Int         @default(0)
+  earnedCustomColor      Boolean     @default(false)
+  carSettingsDbId        Int         @unique
+  settings               CarSettings @relation(fields: [carSettingsDbId], references: [dbId])
+  vsPlayCount            Int         @default(0)
+  vsBurstCount           Int         @default(0)
+  vsStarCount            Int         @default(0)
+  vsCoolOrWild           Int         @default(0)
+  vsSmoothOrRough        Int         @default(0)
+  vsTripleStarMedals     Int         @default(0)
+  vsDoubleStarMedals     Int         @default(0)
+  vsSingleStarMedals     Int         @default(0)
+  vsPlainMedals          Int         @default(0)
+  rgPlayCount            Int         @default(0)
+  rgWinCount             Int         @default(0)
+  rgTrophy               Int         @default(0)
+  rgScore                Int         @default(0)
+  rgStamp                Int         @default(0)
+  rgAcquireAllCrowns     Boolean     @default(false)
+  rgRegionMapScore       Int[]
+  dressupLevel           Int         @default(0)
+  dressupPoint           Int         @default(0)
+  stPlayCount            Int         @default(0)
+  stClearBits            Int         @default(0)
+  stClearDivCount        Int         @default(0)
+  stClearCount           Int         @default(0)
+  stLoseBits             BigInt      @default(0)
+  stConsecutiveWins      Int         @default(0)
+  stConsecutiveWinsMax   Int         @default(0)
+  stCompleted100Episodes Boolean     @default(false)
 
-    items CarItem[]
+  items CarItem[]
 
-    carStateDbId     Int                @unique
-    state            CarState           @relation(fields: [carStateDbId], references: [dbId])
-    TimeAttackRecord TimeAttackRecord[]
+  carStateDbId     Int                @unique
+  state            CarState           @relation(fields: [carStateDbId], references: [dbId])
+  TimeAttackRecord TimeAttackRecord[]
 }
 
 model CarItem {
-    dbId     Int @id @default(autoincrement())
-    Car      Car @relation(fields: [carId], references: [carId])
-    carId    Int
-    category Int
-    itemId   Int
-    amount   Int
+  dbId     Int @id @default(autoincrement())
+  Car      Car @relation(fields: [carId], references: [carId])
+  carId    Int
+  category Int
+  itemId   Int
+  amount   Int
 }
 
 model CarSettings {
-    dbId Int  @id @default(autoincrement())
-    car  Car?
+  dbId Int  @id @default(autoincrement())
+  car  Car?
 
-    view               Boolean @default(true)
-    transmission       Boolean @default(false)
-    retire             Boolean @default(false)
-    meter              Int     @default(0)
-    navigationMap      Boolean @default(true)
-    volume             Int     @default(1)
-    bgm                Int     @default(0)
-    nameplate          Int     @default(0)
-    nameplateColor     Int     @default(0)
-    terminalBackground Int     @default(0)
+  view               Boolean @default(true)
+  transmission       Boolean @default(false)
+  retire             Boolean @default(false)
+  meter              Int     @default(0)
+  navigationMap      Boolean @default(true)
+  volume             Int     @default(1)
+  bgm                Int     @default(0)
+  nameplate          Int     @default(0)
+  nameplateColor     Int     @default(0)
+  terminalBackground Int     @default(0)
 }
 
 model CarState {
-    dbId Int  @id @default(autoincrement())
-    car  Car?
+  dbId Int  @id @default(autoincrement())
+  car  Car?
 
-    hasOpponentGhost Boolean @default(false)
-    eventJoined      Boolean @default(false)
-    transferred      Boolean @default(false)
-    toBeDeleted      Boolean @default(false)
+  hasOpponentGhost Boolean @default(false)
+  eventJoined      Boolean @default(false)
+  transferred      Boolean @default(false)
+  toBeDeleted      Boolean @default(false)
 }
 
 model TimeAttackRecord {
-    dbId Int @id @default(autoincrement())
+  dbId Int @id @default(autoincrement())
 
-    car   Car @relation(fields: [carId], references: [carId])
-    carId Int
+  car   Car @relation(fields: [carId], references: [carId])
+  carId Int
 
-    model        Int // Car model, literally just the `model` field from Car
-    time         Int
-    course       Int
-    isMorning    Boolean
-    section1Time Int     @map("section1Time")
-    section2Time Int     @map("section2Time")
-    section3Time Int     @map("section3Time")
-    section4Time Int     @map("section4Time")
-    section5Time Int?    @map("section5Time")
-    section6Time Int?    @map("section6Time")
-    section7Time Int?    @map("section7Time")
-    tunePower    Int     @default(0) // Car Power
-    tuneHandling Int     @default(0) // Car Handling
+  model        Int // Car model, literally just the `model` field from Car
+  time         Int
+  course       Int
+  isMorning    Boolean
+  section1Time Int     @map("section1Time")
+  section2Time Int     @map("section2Time")
+  section3Time Int     @map("section3Time")
+  section4Time Int     @map("section4Time")
+  section5Time Int?    @map("section5Time")
+  section6Time Int?    @map("section6Time")
+  section7Time Int?    @map("section7Time")
+  tunePower    Int     @default(0) // Car Power
+  tuneHandling Int     @default(0) // Car Handling
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,10 +18,6 @@ export interface UnixOptions {
 
 export interface GameOptions {
 
-    // If set to 1, gives the player a random colour for each of the special cars.
-    // If set to 2, allows the player to pick any of the colours (more cluttered)
-	grantBonusScratchCars: number;
-
     // If set to 1, all gift cars (i.e. S2000, S660, etc. will be fully tuned.)
     // If set to 0, they will be left at their default tune (i.e. stock, basic tune, etc.)
     giftCarsFullyTuned: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,8 +17,6 @@ export interface UnixOptions {
 }
 
 export interface GameOptions {
-    // If set to 1, all scratch rewards will be granted to players (including cars)
-	grantAllScratchRewards: number;
 
     // If set to 1, gives the player a random colour for each of the special cars.
     // If set to 2, allows the player to pick any of the colours (more cluttered)
@@ -26,7 +24,25 @@ export interface GameOptions {
 
     // If set to 1, all gift cars (i.e. S2000, S660, etc. will be fully tuned.)
     // If set to 0, they will be left at their default tune (i.e. stock, basic tune, etc.)
-    giftCarsFullyTuned: number, 
+    giftCarsFullyTuned: number;
+    
+    // If set to 1, the scratch game will be enabled and the player 
+    // will be allowed to scratch boxes once every day. If this is 
+    // set to 0, the scratch sheet will always be unavailable, 
+    // however previously recieved items (or items provided by 
+    // grantAllScratchRewards) will still be available. If the 
+    // value is set to 2, there will be no limits on the number 
+    // of times the player can scratch daily.
+    scratchEnabled: number;
+    
+    // If set to 0, the standard scratch sheets (Same as the actual game)
+    // will be available in order, e.g. R2, Corolla, and so on. 
+    
+    // If it is set to 1, random scratch sheets will be generated 
+    // (with 1 scratch car, 25 window stickers, and 24 versus markers infinitely.)
+
+    // OPTION 1 IS IN PROGRESS! PLEASE USE OPTION 2 FOR NOW!
+    scratchType: number;
 
     // Amount of full-tunes to grant to newly registered cards
     grantFullTuneTicketToNewUsers: number;

--- a/src/modules/game.ts
+++ b/src/modules/game.ts
@@ -3,7 +3,7 @@ import { Module } from "../module";
 import * as wm from "../wmmt/wm.proto";
 import * as svc from "../wmmt/service.proto";
 import { prisma } from "..";
-import { Car, ScratchSheet, ScratchSquare, User } from "@prisma/client";
+import { Car, User } from "@prisma/client";
 import { Config } from "../config";
 import Long from "long";
 import { userInfo } from "os";

--- a/src/modules/game.ts
+++ b/src/modules/game.ts
@@ -1,4 +1,4 @@
-import { Application } from "express";
+import e, { Application } from "express";
 import { Module } from "../module";
 import * as wm from "../wmmt/wm.proto";
 import * as svc from "../wmmt/service.proto";
@@ -8,6 +8,8 @@ import { Config } from "../config";
 import Long from "long";
 import { userInfo } from "os";
 import { config } from "dotenv";
+import * as scratch from "../util/scratch";
+import { envelopeItemTypeToDataCategory } from "@sentry/utils";
 
 export default class GameModule extends Module {
     register(app: Application): void {
@@ -172,6 +174,8 @@ export default class GameModule extends Module {
 						break;
 					}
 			}
+
+			// Update car
 			await prisma.car.update({
 				where: {
 					carId: body.carId,
@@ -185,6 +189,8 @@ export default class GameModule extends Module {
 					tuneHandling: body.car!.tuneHandling!,
 				}
 			})
+
+			// Update car settings
 			await prisma.carSettings.update({
 				where: {
 					dbId: car!.carSettingsDbId
@@ -193,23 +199,54 @@ export default class GameModule extends Module {
 					...body.setting
 				}
 			});
+
+			// Update user
 			let user = await prisma.user.findFirst({
 				where: {
 					id: body.car!.userId!
 				}
 			});
-			let storedTutorials = user!.tutorials;
-			body.confirmedTutorials.forEach(
-				(idx) => storedTutorials[idx] = true
-			);
-			await prisma.user.update({
-				where: {
-					id: body.car!.userId!
-				},
-				data: {
-					tutorials: storedTutorials
+
+			// User object exists
+			if (user)
+			{
+				// Get user tutorials
+				let storedTutorials = user!.tutorials;
+
+				// Update any seen tutorials
+				body.confirmedTutorials.forEach(
+					(idx) => storedTutorials[idx] = true
+				);
+
+				// Get the order of the user's cars
+				let carOrder = user?.carOrder;
+
+				// Get the index of the selected car
+				let index = carOrder.indexOf(body.carId);
+
+				// If the selected car is not first
+				if (index > 0)
+				{
+					// Remove that index from the array
+					carOrder.slice(index);
+
+					// Add it back to the front
+					carOrder.unshift(body.carId);
 				}
-			});
+
+				// Otherwise, just ignore it
+
+				// Update the values
+				await prisma.user.update({
+					where: {
+						id: body.car!.userId!
+					},
+					data: {
+						tutorials: storedTutorials, 
+						carOrder: carOrder
+					}
+				});
+			}
 
 			let msg = {
 				error: wm.wm.protobuf.ErrorCode.ERR_SUCCESS,
@@ -228,6 +265,8 @@ export default class GameModule extends Module {
 
 			let body = wm.wm.protobuf.LoadUserRequest.decode(req.body);
 
+			
+
 			let user = await prisma.user.findFirst({
 				where: {
 					chipId: body.cardChipId,
@@ -238,8 +277,7 @@ export default class GameModule extends Module {
 						include: {
 							state: true,
 						}
-					},
-					unusedTickets: true
+					}
 				}
 			});
 
@@ -327,7 +365,8 @@ export default class GameModule extends Module {
 							data: {
 								userId: user.id,
 								category: wm.wm.protobuf.ItemCategory.CAT_CAR_TICKET_FREE,
-								itemId: 5
+								itemId: 5, 
+								type: 0 // Car Ticket
 							}
 						});
 					}
@@ -344,25 +383,92 @@ export default class GameModule extends Module {
 				return;
 			}
 
-			// console.log(user);
-
-			let carStates = user.cars.map(e => e.state);
-			
-			let tickets = (user.unusedTickets || []).map(x => {
-				return {
-					itemId: x.itemId,
-					userItemId: x.dbId,
-					category: x.category
+			// Get the number of scratch cards for the user
+			let scratchSheetCount = await prisma.scratchSheet.count({
+				where: {
+					userId: user!.id
 				}
-			});
-			
+			})
+
+			// While the user's scratch sheet count is greater
+			// than the number of scratch sheets generated
+			while (scratchSheetCount < user!.lastSheet)
+			{
+				// Generate a new scratch sheet for the user
+				await scratch.generateScratchSheet(user!.id, ++scratchSheetCount);
+			}
+
+			// Get the user's cars
+			let cars = user.cars; 
+
+			// If the car order array has not been created
+			if (user.carOrder.length > 0)
+			{
+				// Sort the player's car list using the car order property
+				user.cars = user.cars.sort(function(a, b){
+
+					// User, and both car IDs exist
+					if (user)
+					{
+						// Compare both values using the car order array
+						let compare = user?.carOrder.indexOf(a!.carId) - user?.carOrder.indexOf(b!.carId);
+
+						// Return the comparison
+						return compare;
+					}
+					else // Car IDs not present in car order list
+					{
+						throw Error("UserNotFoundException");
+					}
+				});
+			}
+			else // Car order undefined
+			{
+				// We will define it here
+				let carOrder : number[] = [];
+
+				// Loop over all of the user cars
+				for(let car of user.cars)
+				{
+					// Add the car id to the list
+					carOrder.push(car.carId);
+				}
+
+				// Update the car id property for the user
+				await prisma.user.update({
+					where: {
+						id: user.id
+					}, 
+					data: {
+						carOrder: carOrder
+					}
+				})
+			}
+
+			// Get the states of the user's cars
+			let carStates = user.cars.map(e => e.state);
+
+			// Get all of the user's tickets
+			let tickets = await prisma.userItem.findMany({
+				where: {
+					userId: user.id, 
+					type: 0
+				}, 
+				select: {
+					itemId: true, 
+					category: true, 
+					userItemId: true
+				}
+			})
+
 			let msg = {
 				error: wm.wm.protobuf.ErrorCode.ERR_SUCCESS,
 				numOfOwnedCars: user.cars.length,
 				spappState: wm.wm.protobuf.SmartphoneAppState.SPAPP_UNREGISTERED,
 				transferState: wm.wm.protobuf.TransferState.TRANSFERRED,
 				carStates,
-				cars: user.cars,
+				// 5 cars in-game, 200 cars on terminal
+				cars: user.cars.slice(0, body.maxCars),
 				userId: user.id,
 				banapassportAmId: 1,
 				mbId: 1,
@@ -387,18 +493,22 @@ export default class GameModule extends Module {
 			let user = await prisma.user.findFirst({
 				where: {
 					id: body.userId,
-				},
-				include: {
-					unusedTickets: true,
 				}
 			});
-			let tickets = (user?.unusedTickets || []).map(x => {
-				return {
-					itemId: x.itemId,
-					userItemId: x.dbId,
-					category: x.category
+			
+			// Get all of the user's tickets
+			let tickets = await prisma.userItem.findMany({
+				where: {
+					userId: body.userId, 
+					type: 0
+				}, 
+				select: {
+					itemId: true, 
+					category: true, 
+					userItemId: true 
 				}
-			});
+			})
+
 			let notice = (Config.getConfig().notices || []);
 			let noticeWindows = notice.map(a => wm.wm.protobuf.NoticeEntry.NOTICE_UNUSED_1);
             let msg = {
@@ -518,22 +628,53 @@ export default class GameModule extends Module {
 			r.send(Buffer.from(end));
 		})
 
-		// Load unrecieved user items
-		app.post('/method/load_unrecieved_user_items', (req, res) => {
+		// Recieve user items
+		app.post('/method/receive_user_items', async (req, res) => {
+			
+			// Get the request body
+			let body = wm.wm.protobuf.ReceiveUserItemsRequest.decode(req.body);
 
-			// In future, might want to check db for player items
+			// Loop over all of the item IDs 
+			for(let targetItem of body.targetItemIds)
+			{
+				// Get the item info for the target item
+				let item = await prisma.userItem.findFirst({
+					where: {
+						userItemId: targetItem
+					}
+				});
 
-			let msg = {
-				error: wm.wm.protobuf.ErrorCode.ERR_SUCCESS,
-				owned_user_items: [
-					wm.wm.protobuf.UserItem.create({
-						category: 17, 
-						itemId: 1
-					})
-				]
+				// Item is returned
+				if (item)
+				{
+					// Insert the item into the car items
+					await prisma.carItem.create({
+						data: {
+							carId: body.carId, 
+							category: item.category, 
+							itemId: item.itemId, 
+							amount: 1
+						}
+					});
+
+					// Delete the accepted item
+					await prisma.userItem.delete({
+						where: {
+							userItemId: targetItem
+						}
+					});
+				}
+				else // No item found
+				{
+					console.log("Warning: Item " + targetItem + " not found. Item not added.");
+				}
 			}
 
-			let resp = wm.wm.protobuf.LoadUnreceivedUserItemsResponse.encode(msg);
+			let msg = {
+				error: wm.wm.protobuf.ErrorCode.ERR_SUCCESS
+			}
+
+			let resp = wm.wm.protobuf.LoadBookmarksResponse.encode(msg);
 			let end = resp.finish();
 			let r = res
 				.header('Server', 'v388 wangan')
@@ -671,8 +812,6 @@ export default class GameModule extends Module {
 				},
 			});
 
-			// Update the car order (NOT IMPLEMENTED)
-
 			// Update the completed tutorials
 			let storedTutorials = user!.tutorials;
 			
@@ -689,6 +828,21 @@ export default class GameModule extends Module {
 				}
 			});
 
+			// If the car order was modified
+
+			// Update the car order in the table
+			if (body.carOrder.length > 0)
+			{
+				await prisma.user.update({
+					where: {
+						id: body.userId
+					},
+					data: {
+						carOrder: body.carOrder
+					}
+				});
+			}
+
 			let msg = {
 				// Success error code
 				error: wm.wm.protobuf.ErrorCode.ERR_SUCCESS,
@@ -704,199 +858,93 @@ export default class GameModule extends Module {
 				.status(200);
 			r.send(Buffer.from(end));
 		})
-		
-		// Terminal scratch (VERY WIP)
+
+		// Terminal scratch
 		app.post('/method/load_scratch_information', async (req, res) => {
 
 			// Get the information from the request
 			let body = wm.wm.protobuf.LoadScratchInformationRequest.decode(req.body);
 
-			// Commenting all of the scratch card shit out for now
+			// Get the current date/time (unix epoch)
+			let date = Math.floor(new Date().getTime() / 1000)
 
-			/* 
-			// Get all of the scratch sheets for the user
-			let scratchSheets = await prisma.scratchSheet.findMany({
-				where: {
-					userId: body.userId
-				},
-				include: {
-					squares: true
-				}
-			});
+			// Scratch sheet proto
+			let scratchSheetProto : wm.wm.protobuf.ScratchSheet[] = [];
 
-			// No scratch sheets for user
-			if (scratchSheets.length == 0)
+			// Current scratch sheet (default: Sheet 1 (R2))
+			let currentSheet = 1;
+
+			// User has scratched already (default: True)
+			let scratched = 1;
+
+			// Get the scratch sheet configuration
+			let scratchEnabled = Config.getConfig().gameOptions.scratchEnabled;
+
+			// If the scratch game is enabled
+			if (scratchEnabled)
 			{
-				// Create a new scratch sheet for the user
-				let sheet = await prisma.scratchSheet.create({
-					data: {
-						userId: body.userId
-					}
-				})
-
-				// Populate each square (with FT ticket for now)
-				for (let i=0; i<50; i++) {
-					await prisma.scratchSquare.create({
-						data: {
-							sheetId: sheet.id, 
-							category: wm.wm.protobuf.ItemCategory.CAT_RIVAL_MARKER,
-							itemId: 1, 
-							earned: false
-						}
-					});
-				}
-
-				// In future, I will very the way this is populated based on settings
-				// i.e. totally random items, items based upon real arcade, etc. 
-
-				// Get the data for the newly created sheet
-				let newSheet = await prisma.scratchSheet.findFirst({
+				// Get all of the info for the user
+				let user = await prisma.user.findFirst({
 					where: {
-						userId: body.userId
-					},
-					include: {
-						squares: true
+						id: body.userId
 					}
 				});
 
-				// Sheet is created successfully
-				if (newSheet)
+				// Get the protobuf data for the scratch sheet
+				scratchSheetProto = await scratch.getScratchSheetProto(body.userId);
+
+				// User is defined
+				if (user)
 				{
-					// Update the scratch sheet list
-					scratchSheets = [newSheet];
+					// Update the currentSheet, scratched values
+					currentSheet = user.currentSheet;
+
+					// If unlimited scratches is set
+					if (scratchEnabled == 2)
+					{
+						// User can scratch again
+						scratched = 0;
+					}
+					else // Otherwise, daily scratches
+					{
+						// Get the days since epoch
+						let daysSinceEpoch = (date: Date) => {
+							return Math.floor(Number(date)/8.64e7);
+						};
+
+						// Get the days since epoch for current date, last scratched date
+						let currentDate = daysSinceEpoch(new Date(date*1000));
+						let lastScratched = daysSinceEpoch(new Date(user.lastScratched*1000));
+
+						// If unlimited scratches are enabled, or it is at least 
+						// the next day since the user last scratched off
+						if (currentDate > lastScratched)
+						{
+							// User can scratch again
+							scratched = 0;
+						}
+						else // It is not the next day / other error
+						{
+							// User cannot scratch
+							scratched = 1;
+						}
+					}
 				}
 			}
-
-			// Generate the scratch sheet proto
-			let scratch_sheets : wm.wm.protobuf.ScratchSheet[] = [];
-
-			// Loop over all of the protos
-			for(let sheet of scratchSheets)
-			{
-				// Get all of the scratch squares
-				let scratch_squares : wm.wm.protobuf.ScratchSheet.ScratchSquare[] = [];
-
-				// Loop over all of the squares
-				for (let square of sheet.squares)
-				{
-					// Add the current square to the protobuf array
-					scratch_squares.push(wm.wm.protobuf.ScratchSheet.ScratchSquare.create({
-						category: square.category, 
-						itemId: square.itemId, 
-						earned: square.earned
-					}));
-				}
-
-				// Add the scratch sheet to the sheets list
-				scratch_sheets.push(
-					wm.wm.protobuf.ScratchSheet.create({
-						squares: scratch_squares
-					})
-				);
-			}
-			*/
-
-			// Debug: Add all items to the 'acceptable items' list
 
 			// Owned user items list
 			let ownedUserItems : wm.wm.protobuf.UserItem[] = [];
 
-			// Get the current date
-			let date = Date.now();
-
-			// If the grant all scratch rewards switch is set, add them to the list
-			if (Config.getConfig().gameOptions.grantAllScratchRewards)
-			{
-				// Grant one of each item every time the menu is loaded
-
-				// Loop over all of the window sticker styles
-				for(let i=1; i<=60; i++)
-				{
-					// Add one of each of the window sticker styles to the list
-					ownedUserItems.push(wm.wm.protobuf.UserItem.create({
-						category: wm.wm.protobuf.ItemCategory.CAT_WINDOW_DECORATION, 
-						itemId: i, 
-						earnedAt: date, 
-					}));
-				}
-
-				// Loop over all of the rival markers
-				for(let i=1; i<=80; i++)
-				{
-					// Add one of each of the rival markers to the list
-					ownedUserItems.push(wm.wm.protobuf.UserItem.create({
-						category: wm.wm.protobuf.ItemCategory.CAT_RIVAL_MARKER, 
-						itemId: i, 
-						earnedAt: date, 
-					}));
-				}
-
-				// Item ID for the scratch cars
-				let scratchCarIds = [4, 3, 1, 2, 5, 6, 16, 17, 18, 19, 20, 21];
-				
-				// I literally ripped this from mozilla.org lmfao
-				let getValueInRange = (min: number, max: number) => {
-					return Math.random() * (max - min) + min;
-				}
-
-				// If the grant bonus scratch cars switch is set, switch on the value
-				switch(Config.getConfig().gameOptions.grantBonusScratchCars)
-				{
-					case 1: // Grant one of each bonus scratch car (random colour)
-
-						// Mini Cooper						
-						scratchCarIds.push(getValueInRange(7, 15));
-
-						// S660
-						scratchCarIds.push(getValueInRange(22, 27));
-
-						// S2000
-						scratchCarIds.push(getValueInRange(28, 36));
-
-						// Roadster RF, 280ZT, Leopard
-						scratchCarIds = scratchCarIds.concat([37, 38, 39]);
-
-						break;
-					case 2: // Grant every colour of each bonus scratch cars
-
-						// Mini Cooper						
-						scratchCarIds = scratchCarIds.concat([7, 8, 9, 10, 11, 12, 13, 14, 15]);
-
-						// S660
-						scratchCarIds = scratchCarIds.concat([22, 23, 24, 25, 26, 27]);
-
-						// S2000
-						scratchCarIds = scratchCarIds.concat([28, 29, 30, 31, 32, 33, 34, 35, 36]);
-
-						// Roadster RF, 280ZT, Leopard
-						scratchCarIds = scratchCarIds.concat([37, 38, 39]);
-
-						break;
-					default: // Do not grant bonus scratch cars
-						break;
-				}
-
-				// Loop over all of the scratch cars
-				for(let car of scratchCarIds)
-				{
-					// Add one of each of the rival markers to the list
-					ownedUserItems.push(wm.wm.protobuf.UserItem.create({
-						category: 201, // Scratch Car
-						itemId: car, 
-						earnedAt: date, 
-					}));
-				}
-			}
+			// Get the user items list
+			ownedUserItems = await scratch.getScratchItemList(body.userId, date);
 
 			let msg = {
 				error: wm.wm.protobuf.ErrorCode.ERR_SUCCESS,
-				scratchSheets: [],
-				currentSheet: 0,
-				numOfScratched: 0, 
+				scratchSheets: scratchSheetProto,
+				currentSheet: currentSheet, 
+				numOfScratched: scratched, 
 				ownedUserItems: ownedUserItems
 			}
-
-			// console.log(scratch_sheets);
 
 			let resp = wm.wm.protobuf.LoadScratchInformationResponse.encode(msg);
 			let end = resp.finish();
@@ -908,87 +956,168 @@ export default class GameModule extends Module {
 			r.send(Buffer.from(end));
 		});
 
+		// Change terminal scratch page
+		app.post('/method/turn_scratch_sheet', async (req, res) => {
+
+			let body = wm.wm.protobuf.TurnScratchSheetRequest.decode(req.body);
+
+			// Update the active scratch sheet
+			await prisma.user.update({
+				where: {
+					id: body.userId
+				}, 
+				data: {
+					currentSheet: body.targetSheet
+				}
+			});
+
+			let msg = {
+				error: wm.wm.protobuf.ErrorCode.ERR_SUCCESS,
+			}
+
+			let resp = wm.wm.protobuf.TurnScratchSheetResponse.encode(msg);
+			let end = resp.finish();
+			let r = res
+				.header('Server', 'v388 wangan')
+				.header('Content-Type', 'application/x-protobuf; revision=8053')
+				.header('Content-Length', end.length.toString())
+				.status(200);
+			r.send(Buffer.from(end));
+		})
+
+		// Update scratch sheet
 		app.post('/method/save_scratch_sheet', async (req, res) => {
 
 			// Get the information from the request
 			let body = wm.wm.protobuf.SaveScratchSheetRequest.decode(req.body);
 
-			/*
+			// Get the current date/time (unix epoch)
+			let date = Math.floor(new Date().getTime() / 1000)
+
+			// Get all of the info for the user
+			let user = await prisma.user.findFirst({
+				where: {
+					id: body.userId
+				}
+			});
+
 			// Get all of the scratch sheets for the user
 			let scratchSheets = await prisma.scratchSheet.findMany({
 				where: {
 					userId: body.userId
 				}, 
 				include: {
-					squares: true
+					squares: {
+						orderBy: {
+							id: 'asc'
+						}
+					}
 				}
 			})
 
-			// Get the target scratch sheet 
-			let scratchSheet = scratchSheets[Number(body.targetSheet)];
+			// Get the target scratch sheet (subtract one for zero-index)
+			let scratchSheet = scratchSheets[Number(body.targetSheet)-1];
 
 			// Get all of the squares for the scratch sheet
 			let scratchSquares = await prisma.scratchSquare.findMany({
 				where: {
 					sheetId: scratchSheet.id
+				}, 
+				orderBy: {
+					id: 'asc'
 				}
 			});
 
 			// Get the target scratch square
 			let scratchSquare = scratchSquares[Number(body.targetSquare)];
 
-			// Update the revealed scratch square
-			await prisma.scratchSquare.update({
-				where: {
-					id: scratchSquare.id
-				}, 
-				data: {
-					earned: true
-				}
+			// Get the item from the scratch square
+			let earnedItem = wm.wm.protobuf.UserItem.create({
+				category: scratchSquare.category, 
+				itemId: scratchSquare.itemId, 
+				earnedAt: date
 			});
 
-			// Get the number of scratched squares on the page
-			let numOfScratched = await prisma.scratchSquare.count({
-				where: {
-					sheetId: scratchSheet.id, 
-					earned: true
-				}
-			})
-
-			// Generate the scratch sheet proto
-			let scratch_sheets : wm.wm.protobuf.ScratchSheet[] = [];
-
-			// Loop over all of the protos
-			for(let sheet of scratchSheets)
+			try // Attempt to update scratch sheet
 			{
-				// Get all of the scratch squares
-				let scratch_squares : wm.wm.protobuf.ScratchSheet.ScratchSquare[] = [];
+				// Add the item to the user's scratch items list
+				await prisma.userItem.create({
+					data: {
+						userId: body.userId,
+						category: scratchSquare.category, 
+						itemId: scratchSquare.itemId, 
+						type: 1,  // Scratch item
+						earnedAt: date
+					}
+				});
 
-				// Loop over all of the squares
-				for (let square of sheet.squares)
+				// Update the revealed scratch square
+				await prisma.scratchSquare.update({
+					where: {
+						id: scratchSquare.id
+					}, 
+					data: {
+						earned: true
+					}
+				});
+
+				// Update the last scratched timestamp
+				await prisma.user.update({
+					where: {
+						id: body.userId
+					}, 
+					data: {
+						lastScratched: date
+					}
+				}); 
+				
+				// If the box we uncovered is the car
+				if (scratchSquare.category == 201)
 				{
-					// Add the current square to the protobuf array
-					scratch_squares.push(wm.wm.protobuf.ScratchSheet.ScratchSquare.create({
-						category: square.category, 
-						itemId: square.itemId, 
-						earned: square.earned
-					}));
-				}
+					// If the current sheet is the last sheet
+					if (body.targetSheet == user?.lastSheet)
+					{
+						// Update the last sheet value
+						let lastSheet = body.targetSheet + 1;
 
-				// Add the scratch sheet to the sheets list
-				scratch_sheets.push(
-					wm.wm.protobuf.ScratchSheet.create({
-						squares: scratch_squares
-					})
-				);
+						// Increment the player's maximum scratch sheets
+						await prisma.user.update({
+							where: {
+								id: body.userId
+							}, 
+							data: {
+								lastSheet: lastSheet
+							}
+						});
+
+						// Generate a new scratch sheet for the user
+						await scratch.generateScratchSheet(body.userId, lastSheet)
+					}
+					else // We are not on the last sheet
+					{
+						// Should never happen, do nothing
+					}
+				}
+			} 
+			catch (error) // Failed to update scratch sheet
+			{
+				console.log("Failed to update scratch sheet! Reason:", error);	
 			}
-			*/
+			
+			// Get the updated content for the scratch sheet
+
+			// Scratch sheet proto
+			let scratchSheetProto : wm.wm.protobuf.ScratchSheet[] = []
+
+			// Get the updated scratch sheet proto
+			scratchSheetProto = await scratch.getScratchSheetProto(body.userId);
 
 			let msg = {
 				error: wm.wm.protobuf.ErrorCode.ERR_SUCCESS,
-				scratchSheets : [],
+				scratchSheets : scratchSheetProto,
 				currentSheet: body.targetSheet, 
-				numOfScratched: 0, 
+				numOfScratched: 1, 
+				earnedItem: earnedItem
 			}
 
 			let resp = wm.wm.protobuf.SaveScratchSheetResponse.encode(msg);
@@ -1003,6 +1132,7 @@ export default class GameModule extends Module {
 
 		app.post('/method/update_car', async (req, res) => {
 			let body = wm.wm.protobuf.UpdateCarRequest.decode(req.body);
+
 			let car = await prisma.car.findFirst({
 				where: {
 					carId: body.carId
@@ -1011,11 +1141,40 @@ export default class GameModule extends Module {
 					settings: true
 				}
 			});
+
+			// Update the car info
+			await prisma.car.update({
+				where: {
+					carId: body.carId
+				}, 
+				data: {
+					// Car components customisable in terminal
+					customColor: body.car?.customColor || 0,
+					wheel: body.car?.wheel || 0,
+					aero: body.car?.aero || 0,
+					bonnet: body.car?.bonnet || 0,
+					wing: body.car?.wing || 0,
+					mirror: body.car?.mirror || 0,
+					neon: body.car?.neon || 0,
+					trunk: body.car?.trunk || 0,
+					plate: body.car?.plate || 0,
+					plateColor: body.car?.plateColor || 0,
+					windowSticker: body.car?.windowSticker || false, 
+					windowStickerString: body.car?.windowStickerString || 'ＷＡＮＧＡＮ',
+					windowStickerFont: body.car?.windowStickerFont || 0,
+					rivalMarker: body.car?.rivalMarker || 0,
+					aura: body.car?.aura || 0,
+					auraMotif: body.car?.auraMotif || 0
+				}
+			})
+			
+			// Update the car settings
 			await prisma.carSettings.update({
 				where: {
 					dbId: car?.carSettingsDbId,
 				},
 				data: {
+
 					...body.setting
 				}
 			});
@@ -1052,7 +1211,8 @@ export default class GameModule extends Module {
 			// Get the create car request body
 			let body = wm.wm.protobuf.CreateCarRequest.decode(req.body);
 
-			console.log(body);
+			// Get the current date/time (unix epoch)
+			let date = Math.floor(new Date().getTime() / 1000)
 
 			// Retrieve user from card chip / user id
 			let user: User | null;
@@ -1087,7 +1247,12 @@ export default class GameModule extends Module {
 			})
 
 			// Sets if full tune is used or not
-			let fullyTuned = false;
+			// let fullyTuned = false;
+
+			// 0: Stock Tune
+			// 1: Basic Tune (600 HP)
+			// 2: Fully Tuned (840 HP)
+			let tune = 0;
 
 			// If a user item has been used
 			if (body.userItemId) 
@@ -1097,28 +1262,90 @@ export default class GameModule extends Module {
 				// Remove the user item from the database
 				let item = await prisma.userItem.delete({
 					where: {
-						dbId: body.userItemId
+						userItemId: body.userItemId
 					}
 				});
 
-				console.log(`Item category was ${item.category} and item game ID was ${item.itemId}`);
-				
-				// If the item used was a full tune ticket
-				if (item.category == wm.wm.protobuf.ItemCategory.CAT_CAR_TICKET_FREE &&
-					item.itemId == 5)
-				{
-					// Fully tuned is true
-					fullyTuned = true;
-				}
-
 				console.log('Item deleted!');
+
+				switch(item.category)
+				{
+					case 203: // Car Tune Ticket
+
+						// Switch on item id
+						switch(item.itemId)
+						{
+							// Discarded Vehicle Card
+							case 1: tune = 1; break;
+							case 2: tune = 1; break;
+							case 3: tune = 1; break;
+
+							// Fully Tuned Ticket
+							case 5: tune = 2; break;
+
+							default: // Unknown item type, throw unsupported error
+								throw Error("Unsupported itemId: " + item.itemId); 
+						}
+						break;
+
+					case 201: // Special Car Ticket
+
+						// Fully tuned special cars
+						if (scratch.fullyTunedCars.includes(item.itemId))
+						{
+							// Car is fully tuned
+							tune = 2;
+						}
+						// Basic tuned special cars
+						if (scratch.basicTunedCars.includes(item.itemId))
+						{
+							// If gift cars fully tuned is set
+							if (Config.getConfig().gameOptions.giftCarsFullyTuned)
+							{
+								// Car is fully tuned
+								tune = 2;
+							}
+							else // Gift cars fully tuned not set
+							{
+								// Car is basic tuned
+								tune = 1;
+							}
+						}
+						// Stock tuned special cars
+						if (scratch.stockTunedCars.includes(item.itemId))
+						{
+							// If gift cars fully tuned is set
+							if (Config.getConfig().gameOptions.giftCarsFullyTuned)
+							{
+								// Car is fully tuned
+								tune = 2;
+							}
+							else // Gift cars fully tuned not set
+							{
+								// Car is stock
+								tune = 0;
+							}
+						}
+						break;
+				}
+				console.log(`Item category was ${item.category} and item game ID was ${item.itemId}`);
 			}
+
+			// Other cases, may occur if item is not detected as 'used'
+
 			// User item not used, but car has 740 HP by default
 			else if (body.car && 
 				(body.car.tunePower == 17) && (body.car.tuneHandling == 17))
 			{
-				// Set fully tuned to be true
-				fullyTuned = true;
+				// Car is fully tuned
+				tune = 2;
+			}
+			// User item not used, but car has 600 HP by default
+			else if (body.car && 
+				(body.car.tunePower == 10) && (body.car.tuneHandling == 10))
+			{
+				// Car is basic tuned
+				tune = 1;
 			}
 			// User item not used, but gift cars fully tuned switch is set
 			else if (Config.getConfig().gameOptions.giftCarsFullyTuned)
@@ -1136,7 +1363,7 @@ export default class GameModule extends Module {
 				if (body.car.visualModel && event_cars.includes(body.car.visualModel))
 				{
 					// Set full tune used to be true
-					fullyTuned = true;
+					tune = 2;
 				}
 			}
 
@@ -1155,29 +1382,53 @@ export default class GameModule extends Module {
 				carSettingsDbId: settings.dbId,
 				carStateDbId: state.dbId,
 				regionId: body.car.regionId!,
+				lastPlayedAt: date,
 			};
 
-			// Additional car values (for full tune)
+			// Additional car values (for basic / full tune)
 			let additionalInsert = {
 
 			}
 
-			// Car is fully tuned
-			if (fullyTuned) {
+			// Switch on tune status
+			switch(tune)
+			{
+				// 0: Stock, nothing extra
 
-				// Updated default values
-				carInsert.level = 8; // C3
-				carInsert.tunePower = 17; // 740 HP
-				carInsert.tuneHandling = 17; // 740 HP
+				case 1: // Basic Tune
 
-				// Additional full tune values
-				additionalInsert = {
-					stClearBits: 0,
-					stLoseBits: 0,
-					stClearCount: 80,
-					stClearDivCount: 4,
-					stConsecutiveWins: 80
-				};
+					// Updated default values
+					carInsert.level = 2; // C3
+					carInsert.tunePower = 10; // 600 HP
+					carInsert.tuneHandling = 10; // 600 HP
+	
+					// Additional basic tune values
+					additionalInsert = {
+						stClearBits: 0,
+						stLoseBits: 0,
+						stClearCount: 20,
+						stClearDivCount: 1,
+						stConsecutiveWins: 20
+					};
+					break;
+
+				case 2: // Fully Tuned
+
+					// Updated default values
+					carInsert.tunePower = 17; // 740 HP
+					carInsert.tuneHandling = 17; // 740 HP
+
+					// Rank
+					carInsert.level = 8; // C3
+	
+					// Additional full tune values
+					additionalInsert = {
+						stClearBits: 0,
+						stLoseBits: 0,
+						stClearCount: 80,
+						stClearDivCount: 4,
+						stConsecutiveWins: 80
+					};
 			}
 
 			// Insert the car into the database
@@ -1185,6 +1436,22 @@ export default class GameModule extends Module {
 				data: {
 					...carInsert,
 					...additionalInsert,
+				}
+			});
+
+			// Get the user's current car order
+			let carOrder = user.carOrder;
+
+			// Add the new car to the front of the id
+			carOrder.unshift(car.carId);
+
+			// Add the car to the front of the order
+			await prisma.user.update({
+				where: {
+					id: user.id
+				}, 
+				data: {
+					carOrder: carOrder
 				}
 			});
 
@@ -1234,7 +1501,8 @@ export default class GameModule extends Module {
 				transferred: false,
 				...car!,
 				stLoseBits: longLoseBits,
-				ownedItems: car!.items
+				ownedItems: car!.items,
+				lastPlayedAt: car!.lastPlayedAt
 			};
 			let resp = wm.wm.protobuf.LoadCarResponse.encode(msg);
 			let end = resp.finish();
@@ -1267,8 +1535,6 @@ export default class GameModule extends Module {
 					carId: body.carId
 				}
 			});
-
-			console.log(records);
 
 			// Loop over all of the records
 			for(let record of records)

--- a/src/modules/game.ts
+++ b/src/modules/game.ts
@@ -913,6 +913,7 @@ export default class GameModule extends Module {
 			// Get the information from the request
 			let body = wm.wm.protobuf.SaveScratchSheetRequest.decode(req.body);
 
+			/*
 			// Get all of the scratch sheets for the user
 			let scratchSheets = await prisma.scratchSheet.findMany({
 				where: {
@@ -981,16 +982,13 @@ export default class GameModule extends Module {
 					})
 				);
 			}
+			*/
 
 			let msg = {
 				error: wm.wm.protobuf.ErrorCode.ERR_SUCCESS,
-				scratchSheets : scratch_sheets,
+				scratchSheets : [],
 				currentSheet: body.targetSheet, 
-				numOfScratched: numOfScratched, 
-				earnedItem: wm.wm.protobuf.UserItem.create({
-					category: scratchSquare.category, 
-					itemId: scratchSquare.itemId, 
-				})
+				numOfScratched: 0, 
 			}
 
 			let resp = wm.wm.protobuf.SaveScratchSheetResponse.encode(msg);

--- a/src/util/scratch.ts
+++ b/src/util/scratch.ts
@@ -1,0 +1,408 @@
+import { isRateLimited } from "@sentry/utils";
+import { prisma } from "..";
+import { Config } from "../config";
+import * as wm from "../wmmt/wm.proto";
+
+// *** CONSTANTS ***
+
+// Scratch Sheets
+let scratchSheets = [
+    [ // Sheet 1
+        [201, 4], // R2
+
+        // Window Stickers
+        [25, 8], [25, 8], [25, 8], [25, 8], [25, 8], // BAT
+        [25, 6], [25, 6], [25, 6], [25, 6], [25, 6], // SPEAR
+        [25, 24], [25, 24], [25, 24], [25, 24], [25, 24], // PULSE
+        [25, 3], [25, 3], [25, 3], [25, 3], [25, 3], // CIRCLE
+        [25, 14], [25, 14], [25, 14], [25, 14], [25, 14], // TRIBAL
+    
+        // Rival Markers
+        [26, 18], [26, 18], [26, 18], [26, 18], // LIGHTNING
+        [26, 2], [26, 2], [26, 2], [26, 2], // NEON
+        [26, 31], [26, 31], [26, 31], [26, 31], // V
+        [26, 40], [26, 40], [26, 40], [26, 40], // NEW DRIVER
+        [26, 1], [26, 1], [26, 1], [26, 1], // FIRE
+        [26, 17], [26, 17], [26, 17], [26, 17], // TROPICAL
+    ], 
+    [ // Sheet 2
+        [201, 3], //  Corolla
+        
+        // Window Stickers
+        [25, 11], [25, 11], [25, 11], [25, 11], [25, 11], // Thunderbolt
+        [25, 4], [25, 4], [25, 4], [25, 4], [25, 4], // Circle 2
+        [25, 28], [25, 28], [25, 28], [25, 28], [25, 28], // Wangan URL
+        [25, 5], [25, 5], [25, 5], [25, 5], [25, 5], // Triangle
+        [25, 16], [25, 16], [25, 16], [25, 16], [25, 16], // Cards
+
+        // Rival Markers
+        [26, 9], [26, 9], [26, 9], [26, 9], // GRAFFITI
+        [26, 6], [26, 6], [26, 6], [26, 6], // CASUAL
+        [26, 19], [26, 19], [26, 19], [26, 19], // WALL
+        [26, 29], [26, 29], [26, 29], [26, 29], // BAT
+        [26, 2], [26, 2], [26, 2], [26, 2], // ANIMAL
+        [26, 8], [26, 8], [26, 8], [26, 8], // PAINT SPLASH
+    ], 
+    [ // Sheet 3 (Incomplete)
+        [201, 1], // Hiace Van
+
+        // Window Stickers
+        [25, 13], [25, 13], [25, 13], [25, 13], [25, 13], // Arrow
+        [25, 9], [25, 9], [25, 9], [25, 9], // Star
+        [25, 7], [25, 7], [25, 7], [25, 7], // Snake
+        [25, 18], [25, 18], [25, 18], [25, 18], // Heart
+        [25, ], [25, ], [25, ], [25, ], // ????
+
+        // Rival Markers
+        [26, 36], [26, 36], [26, 36], [26, 36], // Pinstripe
+        [26, 5], [26, 5], [26, 5], [26, 5], // Dangerous
+        [26, 14], [26, 14], [26, 14], [26, 14], // Relief
+        [26, 34], [26, 34], [26, 34], [26, 34], // Diamond
+        [26, 4], [26, 4], [26, 4], [26, 4], // Metal
+        [26, 10], [26, 10], [26, 10], [26, 10], // Japonism
+        [26, 20], [26, 20], [26, 20], [26, 20], // Reggae
+    ], 
+    [ // Sheet 4 (Incomplete)
+        [201, 2], // Pajero Evolution
+
+        // Window Stickers
+        [25, 21], [25, 21], [25, 21], [25, 21], [25, 21], // Plum Blossoms
+        [25, 12], [25, 12], [25, 12], [25, 12], // Illumination
+        [25, 10], [25, 10], [25, 10], [25, 10], // Shooting Star
+        [25, 20], [25, 20], [25, 20], [25, 20], // Raimo
+        [25, ], [25, ], [25, ], [25, ], // ????
+
+        // Rival Markers
+        [26, 7], [26, 7], [26, 7], [26, 7], // Flowers
+        [26, 16], [26, 16], [26, 16], [26, 16], // Wood
+        [26, 24], [26, 24], [26, 24], [26, 24], // Studded
+        [26, 33], [26, 33], [26, 33], [26, 33], // Heart
+        [26, 15], [26, 15], [26, 15], [26, 15], // Camo
+        [26, 21], [26, 21], [26, 21], [26, 21], // Decoration
+        [26, 30], [26, 30], [26, 30], [26, 30], // Effect
+    ], 
+    [ // Sheet 5 (Incomplete)
+        [201, 5], // Nismo GT-R (Black)
+
+        // Window Stickers
+        [25, 26], [25, 26], [25, 26], [25, 26], [25, 26], // Paint
+        [25, 29], [25, 29], [25, 29], [25, 29], // Galaga
+        [25, 23], [25, 23], [25, 23], [25, 23], // Maze
+        [25, 2], [25, 2], [25, 2], [25, 2], // Fire Pattern 2
+        [25, ], [25, ], [25, ], [25, ], // ????
+
+        // Rival Markers
+        [26, 39], [26, 39], [26, 39], [26, 39], // Silver Accessory
+        [26, 22], [26, 22], [26, 22], [26, 22], // Tropical 2
+        [26, 25], [26, 25], [26, 25], [26, 25], // Casual 2
+        [26, 28], [26, 28], [26, 28], [26, 28], // Guitar Pick
+        [26, 12], [26, 12], [26, 12], [26, 12], // Mechanical
+        [26, 23], [26, 23], [26, 23], [26, 23], // Monogram
+        [26, 27], [26, 27], [26, 27], [26, 27], // Carbon
+    ], 
+    [ // Sheet 6 (Incomplete)
+        [201, 6], // Fairlady Z (Nismo)
+
+        // Window Stickers
+        [25, 25], [25, 25], [25, 25], [25, 25], [25, 25], // Equaliser
+        [25, 17], [25, 17], [25, 17], [25, 17], // Cards 2
+        [25, 30], [25, 30], [25, 30], [25, 30], // Pac-Man
+        [25, 22], [25, 22], [25, 22], [25, 22], // Seigaiha
+        [25, ], [25, ], [25, ], [25, ], // ????
+
+        // Rival Markers
+        [26, 38], [26, 38], [26, 38], [26, 38], // Hex
+        [26, 13], [26, 13], [26, 13], [26, 13], // Cosmos
+        [26, 35], [26, 35], [26, 35], [26, 35], // Fire Pattern
+        [26, 32], [26, 32], [26, 32], [26, 32], // Feather
+        [26, 11], [26, 11], [26, 11], [26, 11], // Silvercraft
+        [26, 26], [26, 26], [26, 26], [26, 26], // Graffiti 2
+        [26, 37], [26, 37], [26, 37], [26, 37], // Arrow of Light
+    ], 
+    [ // Sheet 7 (Incomplete)
+        [201, 16], // Aristo (Taxi)
+
+        // Window Stickers
+        [25, 32], [25, 32], [25, 32], [25, 32], [25, 32], // Emotion
+        [25, 17], [25, 17], [25, 17], [25, 17], // Pine
+        [25, 30], [25, 30], [25, 30], [25, 30], // Love
+        // [25, 22], [25, 22], [25, 22], [25, 22], // Square
+        [25, 35], [25, 35], [25, 35], [25, 35], [25, 35], // Trap
+
+        // Rival Markers
+        [26, 38], [26, 38], [26, 38], [26, 38], // Shuriken
+        [26, 13], [26, 13], [26, 13], [26, 13], // Electronics
+        [26, 35], [26, 35], [26, 35], [26, 35], // Paint Splash 2
+        [26, 32], [26, 32], [26, 32], [26, 32], // Katana
+        [26, 11], [26, 11], [26, 11], [26, 11], // Steel
+        [26, 26], [26, 26], [26, 26], [26, 26], // Wall 2
+    ], 
+]
+
+// Terminal scratch cars only
+export const scratchCars = [
+    4, 3, 1, 2, 5, 6, 16, 17, 18, 19, 20, 21
+]
+
+// Fully tuned special cars
+export const fullyTunedCars = [
+    4, 3, 1, 2, 5, 6, 16, 17, 18, 19, 20, 21, 39
+];
+
+// Basic tuned special cars
+export const basicTunedCars = [
+    38
+];
+
+// Stock tuned special cars
+export const stockTunedCars = [
+    7, 8, 9, 10, 11, 12, 13, 14, 15, 
+    22, 23, 24, 25, 26, 27, 37, 28, 
+    29, 30, 31, 32, 33, 34, 35, 36
+];
+
+// Non-story racing meters
+const nonStoryMeters = [
+
+    // Meters are added
+    // to scratch as a set
+
+    // Namco / Special Meters
+    [1,4],
+
+    // VSORG / Other Meters
+    [8, 9], 
+    [10, 11], 
+    [12, 13],
+    [14, 15], 
+    [16, 17],
+    [18, 19], 
+    [20, 21], 
+    [22, 23], 
+    [24, 25], 
+    [26, 27]
+];
+
+// *** FUNCTIONS *** 
+
+// Get a random integer within a range
+function getRandom(a: number, b: number)
+{
+    // Return a random integer within the range
+    return Math.floor(Math.random() * (b - a)) + a;
+}
+
+// Generates a random scratch sheet
+// Contents: 
+// 1 Random Scratch Car
+// 25 Random Scratch Stickers
+// 24 Random Scratch Versus Markers
+function getRandomScratchSheet () 
+{
+    // Scratch items list
+    let items : number[][] = [];
+    
+    // Add the random scratch car
+    items.push([201, scratchCars[getRandom(0, scratchCars.length)]])
+
+    // Add the random scratch stickers
+
+    // Five different sticker styles
+    for(let i=0; i<5; i++)
+    {
+        // Get a random versus marker
+        let marker = getRandom(0, 61);
+
+        // Five different instances
+        for(let j=0; j<5; j++)
+        {
+            // Add marker to the list
+            items.push([25, marker])
+        }
+    }
+
+    // Add the random versus markers
+
+    // Six different marker styles
+    for(let i=0; i<6; i++)
+    {
+        // Get a random versus marker
+        let marker = getRandom(0, 81);
+
+        // Four different instances
+        for(let j=0; j<4; j++)
+        {
+            // Add marker to the list
+            items.push([26, marker])
+        }
+    }
+    
+    // Return the items list
+    return items;
+}
+
+// Fisher yates shuffle for the scratch card elements
+function shuffleScratchSheet (array: number[][])
+{
+    // Loop over all of the array elements
+    for (let i = array.length - 1; i > 0; i--) 
+    {
+        // Randomly swap items in the array
+        const j = Math.floor(Math.random() * (i + 1));
+        const temp = array[i];
+        array[i] = array[j];
+        array[j] = temp;
+    }
+
+    // Return the sorted array
+    return array;
+}
+
+// Async function for generating a new scratch sheet
+export async function generateScratchSheet (userId: number, sheetNo: number)
+{
+    // Scratch items list
+    let scratchItems : number[][] = [];
+
+    // Get the scratch sheet type
+    let scratchType = Config.getConfig().gameOptions.scratchType;
+
+    // Switch on the scratch sheet type in the config
+    switch(scratchType)
+    {
+        // More options maybe added in the future
+        
+        case 0: // Same as actual game
+
+            // If the sheet number has associated data
+            if (scratchSheets.length >= sheetNo)
+            {
+                // Get the data for the requested sheet
+                scratchItems = scratchSheets[sheetNo-1];
+            }
+            else // Sheet is out of range
+            {
+                console.log("No data for sheet:", sheetNo);
+            }
+            
+            break;
+
+        case 1: // Infinite random scratch sheets (Standard Items)
+
+            // Generate a random (standard) scratch sheet
+            scratchItems = getRandomScratchSheet();
+
+        default: // Not implemented
+            console.log("Method not implemented: " + scratchType);
+            break;
+    }
+    
+    // If there is at LEAST one scratch item
+    if (scratchItems.length > 0)
+    {
+        // Create a new scratch sheet for the user
+        let sheet = await prisma.scratchSheet.create({
+            data: {
+                userId: userId, 
+                sheetNo: sheetNo
+            }
+        });
+
+        // Shuffle the scratch items list
+        scratchItems = shuffleScratchSheet(scratchItems);
+
+        // Populate the scratch sheet with the items
+        for (let item of scratchItems) {
+            await prisma.scratchSquare.create({
+                data: {
+                    sheetId: sheet.id, 
+                    category: item[0], 
+                    itemId: item[1],
+                    earned: false
+                }
+            });
+        }
+    }
+    else // No scratch items
+    {
+        console.log("No scratch items. Sheet not created");
+    }
+}
+
+export async function getScratchItemList (userId: number, date: number)
+{
+    // Owned user items list
+    let ownedUserItems : wm.wm.protobuf.UserItem[] = [];
+
+    // Get all of the user's scratch items from the database
+    let scratchUserItems = await prisma.userItem.findMany({
+        where: {
+            userId: userId, 
+            type: 1 // Scratch Item
+        }
+    });
+
+    // Loop over all of the returned items
+    for(let item of scratchUserItems)
+    {
+        // Add all of the scratch items to the list
+        ownedUserItems.push(wm.wm.protobuf.UserItem.create({
+            category: item.category, 
+            itemId: item.itemId, 
+            userItemId: item.userItemId,
+            earnedAt: item.earnedAt
+            // no expiration date
+        }));
+    }
+
+    // Return the owned user items list
+    return ownedUserItems;
+}
+
+export async function getScratchSheetProto (userId: number)
+{
+    // Scratch sheet proto
+    let scratchSheetProto : wm.wm.protobuf.ScratchSheet[] = [];
+
+    // Get all of the scratch sheets for the user
+    let scratchSheets = await prisma.scratchSheet.findMany({
+        where: {
+            userId: userId
+        },
+        include: {
+            squares: {
+                orderBy: {
+                    id: 'asc'
+                }
+            }
+        }
+    });
+
+    // Loop over all of the protos
+    for(let sheet of scratchSheets)
+    {
+        // Get all of the scratch squares
+        let scratchSquareProto : wm.wm.protobuf.ScratchSheet.ScratchSquare[] = [];
+
+        // Loop over all of the squares
+        for (let square of sheet.squares)
+        {
+            // Add the current square to the protobuf array
+            scratchSquareProto.push(wm.wm.protobuf.ScratchSheet.ScratchSquare.create({
+                category: square.category, 
+                itemId: square.itemId, 
+                earned: square.earned
+            }));
+        }
+
+        // Add the scratch sheet to the sheets list
+        scratchSheetProto.push(
+            wm.wm.protobuf.ScratchSheet.create({
+                squares: scratchSquareProto
+            })
+        );
+    }
+
+    // Return the scratch sheet proto object
+    return scratchSheetProto;
+}

--- a/src/util/scratch.ts
+++ b/src/util/scratch.ts
@@ -42,7 +42,8 @@ let scratchSheets = [
         [26, 29], [26, 29], [26, 29], [26, 29], // BAT
         [26, 2], [26, 2], [26, 2], [26, 2], // ANIMAL
         [26, 8], [26, 8], [26, 8], [26, 8], // PAINT SPLASH
-    ], 
+    ]
+    /*
     [ // Sheet 3 (Incomplete)
         [201, 1], // Hiace Van
 
@@ -137,6 +138,7 @@ let scratchSheets = [
         [26, 11], [26, 11], [26, 11], [26, 11], // Steel
         [26, 26], [26, 26], [26, 26], [26, 26], // Wall 2
     ], 
+    */ 
 ]
 
 // Terminal scratch cars only
@@ -161,28 +163,6 @@ export const stockTunedCars = [
     29, 30, 31, 32, 33, 34, 35, 36
 ];
 
-// Non-story racing meters
-const nonStoryMeters = [
-
-    // Meters are added
-    // to scratch as a set
-
-    // Namco / Special Meters
-    [1,4],
-
-    // VSORG / Other Meters
-    [8, 9], 
-    [10, 11], 
-    [12, 13],
-    [14, 15], 
-    [16, 17],
-    [18, 19], 
-    [20, 21], 
-    [22, 23], 
-    [24, 25], 
-    [26, 27]
-];
-
 // *** FUNCTIONS *** 
 
 // Get a random integer within a range
@@ -192,54 +172,12 @@ function getRandom(a: number, b: number)
     return Math.floor(Math.random() * (b - a)) + a;
 }
 
-// Generates a random scratch sheet
-// Contents: 
-// 1 Random Scratch Car
-// 25 Random Scratch Stickers
-// 24 Random Scratch Versus Markers
-function getRandomScratchSheet () 
+// Get the days since epoch
+function daysSinceEpoch(date: Date)
 {
-    // Scratch items list
-    let items : number[][] = [];
-    
-    // Add the random scratch car
-    items.push([201, scratchCars[getRandom(0, scratchCars.length)]])
-
-    // Add the random scratch stickers
-
-    // Five different sticker styles
-    for(let i=0; i<5; i++)
-    {
-        // Get a random versus marker
-        let marker = getRandom(0, 61);
-
-        // Five different instances
-        for(let j=0; j<5; j++)
-        {
-            // Add marker to the list
-            items.push([25, marker])
-        }
-    }
-
-    // Add the random versus markers
-
-    // Six different marker styles
-    for(let i=0; i<6; i++)
-    {
-        // Get a random versus marker
-        let marker = getRandom(0, 81);
-
-        // Four different instances
-        for(let j=0; j<4; j++)
-        {
-            // Add marker to the list
-            items.push([26, marker])
-        }
-    }
-    
-    // Return the items list
-    return items;
-}
+    // Return the days since the epoch
+    return Math.floor(Number(date)/8.64e7);
+};
 
 // Fisher yates shuffle for the scratch card elements
 function shuffleScratchSheet (array: number[][])
@@ -258,6 +196,64 @@ function shuffleScratchSheet (array: number[][])
     return array;
 }
 
+// Generates a random scratch sheet
+// Contents: 
+// 1 Random Scratch Car
+// 25 Random Scratch Stickers
+// 24 Random Scratch Versus Markers
+function getRandomScratchSheet (carId: number) 
+{
+    // Scratch items list
+    let items : number[][] = [];
+    
+    // Add the scratch car for the given index
+    items.push([201, scratchCars[carId % scratchCars.length]]);
+
+    // Add the random scratch stickers
+
+    // Five different sticker styles
+    for(let i=0; i<5; i++)
+    {
+        // Get a random versus marker
+        let sticker = getRandom(0, 60);
+
+        // Five different instances
+        for(let j=0; j<5; j++)
+        {
+            // Add marker to the list
+            items.push([25, sticker + 1])
+        }
+    }
+
+    // Add the random versus markers
+
+    // Six different marker styles
+    for(let i=0; i<6; i++)
+    {
+        // Get a random versus marker
+        let marker = getRandom(0, 80);
+
+        // Four different instances
+        for(let j=0; j<4; j++)
+        {
+            // Add marker to the list
+            items.push([26, marker + 1])
+        }
+    }
+    
+    // Return the items list
+    return items;
+}
+
+
+
+// Get the days passed between dates 'a' and 'b'
+export function dayPassed(a: Date, b: Date)
+{
+    // Return 1 if a day has passed since the last scratch, 0 otherwise
+    return daysSinceEpoch(a) > daysSinceEpoch(b) ? 0 : 1;
+}
+
 // Async function for generating a new scratch sheet
 export async function generateScratchSheet (userId: number, sheetNo: number)
 {
@@ -272,7 +268,7 @@ export async function generateScratchSheet (userId: number, sheetNo: number)
     {
         // More options maybe added in the future
         
-        case 0: // Same as actual game
+        case 0: // Same as actual game (randomised after last set)
 
             // If the sheet number has associated data
             if (scratchSheets.length >= sheetNo)
@@ -282,15 +278,16 @@ export async function generateScratchSheet (userId: number, sheetNo: number)
             }
             else // Sheet is out of range
             {
-                console.log("No data for sheet:", sheetNo);
+                // Generate a random (standard) scratch sheet
+                scratchItems = getRandomScratchSheet(sheetNo-1);
             }
-            
             break;
 
         case 1: // Infinite random scratch sheets (Standard Items)
 
             // Generate a random (standard) scratch sheet
-            scratchItems = getRandomScratchSheet();
+            scratchItems = getRandomScratchSheet(sheetNo-1);
+            break;
 
         default: // Not implemented
             console.log("Method not implemented: " + scratchType);


### PR DESCRIPTION
### Configuration Changes:
- Added new scratch-related configuration options:
  - scratchEnabled: If this is set to 0, the terminal scratch will be disabled. 1, the user will be able to use the terminal scratch daily. If this is set to 2, the user will be able to scratch an unlimited number of times.
  - scratchType: If this is set to 0, the scratch sheets will be generated to arcade accuracy (for as many have been implemented, this is currently the first 2). For all sheets after this, the correct car will be available but the rest of the items will be randomly selected. If this is set to 1, all scratch sheets will be randomly generated (But the scratch car order remains the same).
- Removed 'grantAllScratchRewards', 'grantBonusScratchCars' settings as they are no longer used.

### User Table Changes:
- Renamed 'unusedTickets' property in the User table to 'items' - This more accurately reflects that the property is used for ALL associated user items for that user.
- 'carOrder' property which keeps track of the order of the player's cars.
- 'ScratchSheet' property has been added to the user table, which links to all of the scratch sheets for the user.
- 'currentSheet' property has been set to '1' by default, and links to the user's current scratch sheet.
- 'lastSheet' property has been removed as it is redundant.
- 'lastScratched' property has been added which keeps track of the timestamp of the last time the user scratched.

### ScratchSheet Table Changes:
- Table created with id, User, userId, sheetNo, squares properties

### ScratchSquare Table Changes:
- Table created with id, Sheet, SheetId, category, itemId, earned properties

### UserItem Table Changes:
- 'dbId' property renamed to 'userItemId' so it can be used by some of the services in 'game.ts' without requiring a manual rename.
- 'type' property created to keep track of the UserItem 'type'. 0 is for tickets, 1 is for scratch sheet items, and 2 will be for special items in the future.
- 'earnedAt' property created to keep track of the timestamp the item was created / obtained at. 

### Game.ts Code Changes:
- Added code for sorting cars, which works both in-game and on the terminal. Newly created cars are added to the front of the list, and cars are also moved to the front of the list when they are used.
- Resolved a bug where too many cars were being sent to the drive cabinet (if the user had more than 5 cars). Only 5 cars will now be sent to the drive cabinet, and a maximum of 200 sent to the terminal. 
- Fully implemented the terminal scratch system, with support for changing pages, scratching items and adding them to the UserItems table. Earned items are able to be accepted through the terminal.
- Car customisations made using the terminal now save, and are visible in-game. 
- Discarded Vehicle cards have now been implemented, and can be used to register 600 HP cars with 20 stories.
- Gift car system has been rewritten to use the db UserItem objects, instead of hackily using the car hex codes.
- Sections of code which previously referenced the car table 'UnusedTickets' property now access the userItem table, and select rows where the 'userId' matches and the item 'type' is 0 (for tickets). 

### Scratch.ts File Created:
- Contains various utility functions for generating and handling scratch sheets.
- Located in src/util

### Closing Comments
Other changes may have been made, but I've spent a long time reading over the Github diff logs and this is everything relevant I can see. All of the database changes made in this update are relatively minor, and as a result I do not believe they will cause issues for the live version of the game. However, please feel free to let me know if you have any questions or concerns about changes that I've made.
