### PR TITLE
API for ocm ranking (still alpha), FIX ghost play count ocm, unlimited ghost stamp bug, give meter reward bug, etc

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -95,7 +95,8 @@ export default class ApiModule extends Module {
                     car: {
                         select:{
                             carId: true, 
-                            name: true, 
+                            name: true,
+                            defaultColor: true,
                             visualModel: true, 
                             level: true, 
                             title: true, 

--- a/src/api.ts
+++ b/src/api.ts
@@ -10,9 +10,11 @@ export default class ApiModule extends Module {
             extended: true
         }));
     
+
         app.use(express.json({
             type: '*/*'
         }));
+
 
         // API Get Requests
         // Get Current Competition Id
@@ -51,9 +53,6 @@ export default class ApiModule extends Module {
             if(ocmEventDate)
             {
                 message.competitionId = ocmEventDate.competitionId;
-
-                // Send the response to the client
-                res.send(message);
             }
             else{
                 ocmEventDate = await prisma.oCMEvent.findFirst({
@@ -66,11 +65,12 @@ export default class ApiModule extends Module {
                 });
 
                 message.competitionId = ocmEventDate!.competitionId;
-
-                // Send the response to the client
-                res.send(message);
             }
+
+            // Send the response to the client
+            res.send(message);
         });
+
 
         // Get Competition Ranking
         app.get('/api/get_competition_ranking', async (req, res) => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,6 +5,7 @@ import { Module } from "./module";
 
 export default class ApiModule extends Module {
     register(app: Application): void {
+        
         app.use(express.urlencoded({
             type: '*/*',
             extended: true
@@ -17,6 +18,69 @@ export default class ApiModule extends Module {
 
 
         // API Get Requests
+        // Get Current Bayshore Version
+        app.get('/api/bayshore_version', async (req, res) => {
+            let message: any = {
+                error: null,
+                version: null
+            };
+
+            message.version = 'v1.0.0';
+
+            // Send the response to the client
+            res.send(message);
+        })
+
+        // Post Login
+        app.post('/api/login', async (req, res) => {
+
+            // Get the request body
+			let query = req.query;
+
+            // Message Response
+            let message: any = {
+                error: null,
+                user: null
+            };
+
+            // Get the user from the database
+			let user = await prisma.user.findFirst({
+				where: {
+					chipId: query.cardChipId?.toString(),
+					accessCode: query.accessCode?.toString()
+				},
+				include: {
+					cars: {
+						select: {
+							state: true,
+							gtWing: true,
+							lastPlayedPlace: true,
+                            carId: true, 
+                            name: true,
+                            defaultColor: true,
+                            visualModel: true, 
+                            level: true, 
+                            title: true, 
+                            regionId: true, 
+                        }
+					}
+				}
+			});
+            
+            if(user)
+            {
+                message.user = user;
+            }
+            else
+            {
+                message.error = 404
+            }
+
+            // Send the response to the client
+            res.send(message);
+        })
+
+
         // Get Current Competition Id
         app.get('/api/get_competition_id', async (req, res) => {
 
@@ -25,6 +89,7 @@ export default class ApiModule extends Module {
 
             // Message Response
             let message: any = {
+                error: null,
                 competitionId: 1 // default
             };
 
@@ -80,6 +145,7 @@ export default class ApiModule extends Module {
 
             // Message Response
             let message: any = {
+                error: null,
                 cars: [],
                 lastPlayedPlace: 'Bayshore'
             };

--- a/src/api.ts
+++ b/src/api.ts
@@ -35,6 +35,7 @@ export default class ApiModule extends Module {
                                     '"• Fix give meter reward bug if playCount still 0",'+
                                     '"• Hopefully fix ocm HoF bug"'+
                                     '"• Fix duplicate id in carOrder"'+
+                                    '"• Fix OCM HoF wrong shopName"'+
                                 ']'+
                          '}';
             message.version = JSON.parse(myJSON);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,112 @@
+import express, { Application } from "express";
+import { prisma } from ".";
+import { Module } from "./module";
+
+
+export default class ApiModule extends Module {
+    register(app: Application): void {
+        app.use(express.urlencoded({
+            type: '*/*',
+            extended: true
+        }));
+    
+        app.use(express.json({
+            type: '*/*'
+        }));
+
+        // API Get Requests
+        // Get Current Competition Id
+        app.get('/api/get_competition_id', async (req, res) => {
+
+            // Get current date
+            let date = Math.floor(new Date().getTime() / 1000);
+
+            // Message Response
+            let message: any = {
+                competitionId: 1 // default
+            };
+
+            // Get current / previous active OCM Event
+            let ocmEventDate = await prisma.oCMEvent.findFirst({
+                where: {
+					// qualifyingPeriodStartAt is less than current date
+					qualifyingPeriodStartAt: { lte: date },
+		
+					// competitionEndAt is greater than current date
+					competitionEndAt: { gte: date },
+				},
+                orderBy: [
+                    {
+                        dbId: 'desc'
+                    },
+                    {
+                        competitionEndAt: 'desc',
+                    },
+                ],
+                select:{
+                    competitionId: true
+                }
+            });
+
+            if(ocmEventDate)
+            {
+                message.competitionId = ocmEventDate.competitionId;
+
+                // Send the response to the client
+                res.send(message);
+            }
+            else{
+                ocmEventDate = await prisma.oCMEvent.findFirst({
+                    orderBy: {
+                        dbId: 'desc'
+                    },
+                    select:{
+                        competitionId: true
+                    }
+                });
+
+                message.competitionId = ocmEventDate!.competitionId;
+
+                // Send the response to the client
+                res.send(message);
+            }
+        });
+
+        // Get Competition Ranking
+        app.get('/api/get_competition_ranking', async (req, res) => {
+
+            // Get url query
+            let competitionId = Number(req.query.competitionId);
+
+            // Message Response
+            let message: any = {
+                cars: []
+            };
+ 
+            // Get all of the cars matching the query
+            message.cars = await prisma.oCMTally.findMany({
+                where:{
+                    competitionId: competitionId
+                },
+                orderBy: {
+                    result: 'desc'
+                },
+                include:{
+                    car: {
+                        select:{
+                            carId: true, 
+                            name: true, 
+                            visualModel: true, 
+                            level: true, 
+                            title: true, 
+                            regionId: true, 
+                        }  
+                    }
+                }
+            });
+
+            // Send the response to the client
+            res.send(message);
+        });
+    }
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -34,6 +34,7 @@ export default class ApiModule extends Module {
                                     '"• Fix unlimited ghost stamp return (hopefully no more of this)",'+
                                     '"• Fix give meter reward bug if playCount still 0",'+
                                     '"• Hopefully fix ocm HoF bug"'+
+                                    '"• Fix duplicate id in carOrder"'+
                                 ']'+
                          '}';
             message.version = JSON.parse(myJSON);

--- a/src/api.ts
+++ b/src/api.ts
@@ -80,7 +80,8 @@ export default class ApiModule extends Module {
 
             // Message Response
             let message: any = {
-                cars: []
+                cars: [],
+                lastPlayedPlace: 'Bayshore'
             };
  
             // Get all of the cars matching the query
@@ -102,9 +103,17 @@ export default class ApiModule extends Module {
                             title: true, 
                             regionId: true, 
                         }  
-                    }
+                    },
                 }
             });
+
+            let getLastPlayedPlace = await prisma.placeList.findFirst({
+                where:{
+                    id: message.cars[0].lastPlayedPlace
+                }
+            })
+
+            message.lastPlayedPlace = getLastPlayedPlace?.shopName;
 
             // Send the response to the client
             res.send(message);

--- a/src/api.ts
+++ b/src/api.ts
@@ -152,6 +152,38 @@ export default class ApiModule extends Module {
         });
 
 
+        // Get Current Competition Id
+        app.get('/api/get_hof_competition_id', async (req, res) => {
+
+            // Message Response
+            let message: any = {
+                error: null,
+                competitionId: 1 // default
+            };
+
+            // Get current / previous active OCM Event
+            let ocmEventDate = await prisma.oCMTally.findFirst({
+                where:{
+                    periodId: 999999999
+                },
+                orderBy: {
+                    competitionId: 'desc'
+                },
+                select:{
+                    competitionId: true
+                }
+            });
+
+            if(ocmEventDate)
+            {
+                message.competitionId = ocmEventDate.competitionId;
+            }
+
+            // Send the response to the client
+            res.send(message);
+        });
+
+
         // Get Competition Ranking
         app.get('/api/get_competition_ranking', async (req, res) => {
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -25,7 +25,15 @@ export default class ApiModule extends Module {
                 version: null
             };
 
-            message.version = 'v1.0.0';
+            let myJSON = '{"version": "v1.0.0", "log": ['+
+                                                        '"• Fix ghost play count when retiring ocm",'+
+                                                        '"• API for ocm ranking",'+
+                                                        '"• Fix unlimited ghost stamp return (hopefully no more of this)",'+
+                                                        '"• Fix give meter reward bug if playCount still 0",'+
+                                                        '"• Hopefully fix ocm HoF bug"'+
+                                                       ']'+
+                         '}';
+            message.version = JSON.parse(myJSON);
 
             // Send the response to the client
             res.send(message);
@@ -173,13 +181,14 @@ export default class ApiModule extends Module {
                 }
             });
 
-            let getLastPlayedPlace = await prisma.placeList.findFirst({
+            let getLastPlayedPlace = await prisma.oCMGhostBattleRecord.findFirst({
                 where:{
-                    id: message.cars[0].lastPlayedPlace
+                    carId: message.cars[0].carId,
+                    competitionId: competitionId
                 }
             })
 
-            message.lastPlayedPlace = getLastPlayedPlace?.shopName;
+            message.lastPlayedPlace = getLastPlayedPlace?.playedShopName;
 
             // Send the response to the client
             res.send(message);

--- a/src/api.ts
+++ b/src/api.ts
@@ -25,13 +25,16 @@ export default class ApiModule extends Module {
                 version: null
             };
 
-            let myJSON = '{"version": "v1.0.0", "log": ['+
-                                                        '"• Fix ghost play count when retiring ocm",'+
-                                                        '"• API for ocm ranking",'+
-                                                        '"• Fix unlimited ghost stamp return (hopefully no more of this)",'+
-                                                        '"• Fix give meter reward bug if playCount still 0",'+
-                                                        '"• Hopefully fix ocm HoF bug"'+
-                                                       ']'+
+            let myJSON = '{'+
+                            '"version": "v1.0.0",'+
+                            '"log":'+
+                                '['+
+                                    '"• Fix ghost play count when retiring ocm",'+
+                                    '"• API for ocm ranking",'+
+                                    '"• Fix unlimited ghost stamp return (hopefully no more of this)",'+
+                                    '"• Fix give meter reward bug if playCount still 0",'+
+                                    '"• Hopefully fix ocm HoF bug"'+
+                                ']'+
                          '}';
             message.version = JSON.parse(myJSON);
 
@@ -54,7 +57,9 @@ export default class ApiModule extends Module {
             // Get the user from the database
 			let user = await prisma.user.findFirst({
 				where: {
-					chipId: query.cardChipId?.toString(),
+					chipId: {
+                        startsWith: query.cardChipId?.toString()
+                    },
 					accessCode: query.accessCode?.toString()
 				},
 				include: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import fs from 'fs';
 import bodyParser from 'body-parser';
 import AllnetModule from './allnet';
 import MuchaModule from './mucha';
+import ApiModule from './api';
 import { Config } from './config';
 import process from 'process';
 import * as Sentry from '@sentry/node';
@@ -30,8 +31,13 @@ const appRouter = Router();
 const PORT_ALLNET = 80;
 const PORT_MUCHA = 10082;
 const PORT_BNGI = 9002;
+const PORT_API = 9003;
 
 const app = express();
+const muchaApp = express();
+const allnetApp = express();
+const apiApp = express();
+
 app.use(bodyParser.raw({
     type: '*/*'
 }));
@@ -50,9 +56,6 @@ if (useSentry) {
         tracesSampleRate: 0.5
     });
 }
-
-const muchaApp = express();
-const allnetApp = express();
 
 // Get the current timestamp
 let timestamp: string = common.getTimeStamp();
@@ -74,6 +77,11 @@ muchaApp.use((req, res, next) => {
 
 allnetApp.use((req, res, next) => {
     console.log(timestamp+` [ALLNET] ${req.method} ${req.url}`);
+    next()
+});
+
+apiApp.use((req, res, next) => {
+    console.log(timestamp+` [   API] ${req.method} ${req.url}`);
     next()
 });
 
@@ -108,11 +116,12 @@ app.all('*', (req, res) => {
 // Register the ALL.NET / Mucha Server
 new AllnetModule().register(allnetApp);
 new MuchaModule().register(muchaApp);
+new ApiModule().register(apiApp);
 
 // Sentry is in use
 if (useSentry)
 {
-     // Use the sentry error handler
+    // Use the sentry error handler
     app.use(Sentry.Handlers.errorHandler());
 }
 
@@ -140,4 +149,9 @@ https.createServer({key, cert}, muchaApp).listen(PORT_MUCHA, '0.0.0.0', 511, () 
 // Create the game server
 https.createServer({key, cert}, app).listen(PORT_BNGI, '0.0.0.0', 511, () => {
     console.log(`Game server listening on port ${PORT_BNGI}!`);
+})
+
+// Create the API server
+http.createServer(apiApp).listen(PORT_API, '0.0.0.0', 511, () => {
+    console.log(`API server listening on port ${PORT_API}!`);
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,6 @@ https.createServer({key, cert}, app).listen(PORT_BNGI, '0.0.0.0', 511, () => {
 })
 
 // Create the API server
-http.createServer(apiApp).listen(PORT_API, '0.0.0.0', 511, () => {
+http.createServer(apiApp).listen(PORT_API, '0.0.0.0', 4369, () => {
     console.log(`API server listening on port ${PORT_API}!`);
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,10 +80,10 @@ allnetApp.use((req, res, next) => {
     next()
 });
 
-apiApp.use((req, res, next) => {
+/*apiApp.use((req, res, next) => {
     console.log(timestamp+` [   API] ${req.method} ${req.url}`);
     next()
-});
+});*/
 
 // Get all of the files in the modules directory
 let dirs = fs.readdirSync('dist/modules');

--- a/src/modules/cars.ts
+++ b/src/modules/cars.ts
@@ -588,7 +588,6 @@ export default class CarModule extends Module {
 
 			// Get the request body for the update car request
 			let body = wm.wm.protobuf.UpdateCarRequest.decode(req.body);
-			console.log(body);
 
 			// Get the ghost result for the car
 			let cars = body?.car;

--- a/src/modules/cars.ts
+++ b/src/modules/cars.ts
@@ -37,10 +37,12 @@ export default class CarModule extends Module {
 			});
 
 			// Error handling if ghostLevel accidentally set to 0 or more than 10
-			if(car!.ghostLevel < 1){
+			if(car!.ghostLevel < 1)
+			{
 				car!.ghostLevel = 1;
 			}
-			if(car!.ghostLevel > 11){
+			if(car!.ghostLevel > 11)
+			{
 				car!.ghostLevel = 10;
 			}
 
@@ -160,7 +162,37 @@ export default class CarModule extends Module {
 									trailId: trailIdNo1
 								});
 							}
-							
+							else
+							{
+								ghostTrailNo1 = await prisma.oCMGhostTrail.findFirst({
+									where:{
+										carId: getNo1OCM.carId,
+										competitionId: ocmEventDate.competitionId
+									},
+									orderBy:{
+										playedAt: 'desc'
+									}
+								});
+
+								if(ghostTrailNo1)
+								{
+									console.log('Getting registered ghost trail from other table');
+
+									trailIdNo1 = ghostTrailNo1.dbId;
+
+									ghostCarsNo1 = wm.wm.protobuf.GhostCar.create({ 
+										car: {
+											...cars!,
+										},
+										area: ghostTrailNo1.area,
+										ramp: ghostTrailNo1.ramp,
+										path: ghostTrailNo1.path,
+										nonhuman: false,
+										type: wm.wm.protobuf.GhostType.GHOST_NORMAL,
+										trailId: trailIdNo1
+									});
+								}
+							}
 						}
 					}
 				}

--- a/src/modules/game.ts
+++ b/src/modules/game.ts
@@ -173,7 +173,6 @@ export default class GameModule extends Module {
 					windowSticker: body.car!.windowSticker!,
 					lastPlayedAt: timestamps,
 					regionId: body.car!.regionId!,
-					ghostLevel: body.car!.ghostLevel!,
 					rgStamp: common.sanitizeInputNotZero(body.rgResult?.rgStamp),
 					stampSheetCount: common.sanitizeInputNotZero(body.rgResult?.stampSheetCount)
 				}

--- a/src/modules/game.ts
+++ b/src/modules/game.ts
@@ -173,6 +173,7 @@ export default class GameModule extends Module {
 					windowSticker: body.car!.windowSticker!,
 					lastPlayedAt: timestamps,
 					regionId: body.car!.regionId!,
+					ghostLevel: body.car!.ghostLevel!,
 					rgStamp: common.sanitizeInputNotZero(body.rgResult?.rgStamp),
 					stampSheetCount: common.sanitizeInputNotZero(body.rgResult?.stampSheetCount)
 				}

--- a/src/modules/game.ts
+++ b/src/modules/game.ts
@@ -223,15 +223,14 @@ export default class GameModule extends Module {
 				// Get the index of the selected car
 				let index = carOrder.indexOf(body.carId);
 
-				// If the selected car is not first
-				if (index > 0)
-				{
-					// Remove that index from the array
-					carOrder.slice(index);
-
-					// Add it back to the front
-					carOrder.unshift(body.carId);
+				// Only splice array when item is found
+				if (index > -1) 
+				{ 
+					carOrder.splice(index, 1); // 2nd parameter means remove one item only
 				}
+
+				// Add it back to the front
+				carOrder.unshift(body.carId);
 
 				// Otherwise, just ignore it
 

--- a/src/modules/game.ts
+++ b/src/modules/game.ts
@@ -193,7 +193,7 @@ export default class GameModule extends Module {
 			let giveMeterReward = Config.getConfig().gameOptions.giveMeterReward; 
 
 			// Check if this feature activated and check if user's play count is n*100 play
-			if(giveMeterReward === 1 && body.playCount % 100 === 0)
+			if(giveMeterReward === 1 && body.playCount % 100 === 0 &&  body.playCount !== 0)
 			{
 				// Calling give meter reward function (BASE_PATH/src/util/meter_reward.ts)
 				await meter_reward.giveMeterRewards(body);

--- a/src/modules/ghost.ts
+++ b/src/modules/ghost.ts
@@ -110,10 +110,29 @@ export default class GhostModule extends Module {
 				}
 			}
 
-			// Get all of the friend cars for the carId provided
+			// Get all of the challenger car for the carId provided except beated car
+			let checkBeatedCar = await prisma.carStampTarget.findMany({
+                where: {
+                    stampTargetCarId: body.carId,
+					recommended: false
+                },
+				orderBy:{
+					carId: 'asc'
+				}
+            });
+
+			let arrChallengerCarId = [];
+			for(let i=0; i<checkBeatedCar.length; i++)
+			{
+				arrChallengerCarId.push(checkBeatedCar[i].carId);
+			}
+
             let challengers = await prisma.carChallenger.findMany({
                 where: {
-                    carId: body.carId
+                    carId: body.carId,
+					NOT: {
+						challengerCarId: { in: arrChallengerCarId }, // Except beated challenger id
+					},
                 }
             });
 

--- a/src/modules/terminal.ts
+++ b/src/modules/terminal.ts
@@ -990,7 +990,8 @@ export default class TerminalModule extends Module {
 			// Unlock all of the stamp targets for the car
 			await prisma.carStampTarget.updateMany({
 				where: {
-					stampTargetCarId: body.carId
+					stampTargetCarId: body.carId,
+					recommended: true
 				}, 
 				data: {
 					locked: false
@@ -1007,7 +1008,8 @@ export default class TerminalModule extends Module {
 				await prisma.carStampTarget.updateMany({
 					where: {
 						carId: targetCar, 
-						stampTargetCarId: body.carId
+						stampTargetCarId: body.carId,
+						recommended: true
 					}, 
 					data: {
 						locked: true

--- a/src/modules/users.ts
+++ b/src/modules/users.ts
@@ -487,13 +487,18 @@ export default class UserModule extends Module {
 						{
 							let checkRegisteredGhost = await prisma.ghostRegisteredFromTerminal.findFirst({
 								where:{
-									carId: user.cars[i].carId
+									carId: user.cars[i].carId,
+									competitionId: ocmEventDate.competitionId
 								}
 							});
 
 							if(checkRegisteredGhost)
 							{
 								carStates[i].hasOpponentGhost = true;
+							}
+							else
+							{
+								carStates[i].hasOpponentGhost = false;
 							}
 						}
 					}

--- a/src/util/games/ghost.ts
+++ b/src/util/games/ghost.ts
@@ -581,6 +581,21 @@ export async function saveGhostBattleResult(body: wm.protobuf.SaveGameResultRequ
                 }
             }
         }
+
+        // Ghost update data
+        let dataGhost = {
+            rgPlayCount: common.sanitizeInput(body.rgResult!.rgPlayCount), 
+        }
+
+        // Update the car properties
+        await prisma.car.update({
+            where: {
+                carId: body.carId
+            },
+            data: {
+                ...dataGhost
+            }
+        }); 
     }
 
     // Return the value to 'BASE_PATH/src/modules/game.ts'

--- a/src/util/ghost/ghost_ocm.ts
+++ b/src/util/ghost/ghost_ocm.ts
@@ -300,11 +300,11 @@ export async function ocmTallying(body: wm.protobuf.LoadGhostCompetitionInfoRequ
                 // Get the Top 1 Advantage
                 if(top1advantage === null)
                 {
-                    top1advantage = OCMTally[i].result;
+                    top1advantage = OCMTally[0].result;
 
                     let getTrail = await prisma.oCMGhostTrail.findFirst({
                         where:{
-                            carId: OCMTally[i].carId,
+                            carId: OCMTally[0].carId,
                             competitionId: body.competitionId,
                             ocmMainDraw: true
                         }

--- a/start.bat
+++ b/start.bat
@@ -1,2 +1,2 @@
-yarn dev
+node dist
 pause

--- a/start.bat
+++ b/start.bat
@@ -1,2 +1,2 @@
-node dist
+yarn dev
 pause


### PR DESCRIPTION
current PR log :
-Fix ghost play count when retiring ocm
-API for ocm ranking (not sure if this already correct)
-Fix unlimited ghost stamp return (hopefully no more of this)
-Fix give meter reward bug if playCount still 0
-Hopefully fix ocm HoF bug 
-Fix duplicate id in carOrder
-Fix OCM HoF wrong shopName