### PR TITLE
Made sendResponse/protobuf revision check more resilient

### DIFF
--- a/src/modules/cars.ts
+++ b/src/modules/cars.ts
@@ -82,7 +82,7 @@ export default class CarModule extends Module {
 			let message = wm.wm.protobuf.LoadCarResponse.encode(msg);
 
 			// Send the response
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		});
 
 
@@ -121,7 +121,7 @@ export default class CarModule extends Module {
 				let message = wm.wm.protobuf.CreateCarResponse.encode(msg);
 
 				// Send the response
-				common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+				common.sendResponse(message, res, req.rawHeaders);
 
 				return;
 			}
@@ -183,7 +183,7 @@ export default class CarModule extends Module {
             let message = wm.wm.protobuf.CreateCarResponse.encode(msg);
 
             // Send the response
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
 
 
@@ -249,7 +249,7 @@ export default class CarModule extends Module {
             let message = wm.wm.protobuf.UpdateCarResponse.encode(msg);
 
             // Send the response
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
     }
 }

--- a/src/modules/game.ts
+++ b/src/modules/game.ts
@@ -158,7 +158,7 @@ export default class GameModule extends Module {
 			let message = wm.wm.protobuf.SaveGameResultResponse.encode(msg);
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 		
 
@@ -207,7 +207,7 @@ export default class GameModule extends Module {
             let message = wm.wm.protobuf.LoadGameHistoryResponse.encode(msg);
             
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
 
 
@@ -223,7 +223,7 @@ export default class GameModule extends Module {
 			let message = wm.wm.protobuf.SaveChargeResponse.encode(msg);
 			
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
 
 
@@ -347,7 +347,7 @@ export default class GameModule extends Module {
 			let message = wm.wm.protobuf.SaveScreenshotResponse.encode(msg);
 			
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
     }
 }

--- a/src/modules/ghost.ts
+++ b/src/modules/ghost.ts
@@ -78,7 +78,7 @@ export default class GhostModule extends Module {
 					let message = wm.wm.protobuf.LoadGhostBattleInfoResponse.encode(msg);
 
 					// Send the response to the client
-					common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+					common.sendResponse(message, res, req.rawHeaders);
 				}
 			} 
 			else
@@ -87,7 +87,7 @@ export default class GhostModule extends Module {
 				let message = wm.wm.protobuf.LoadGhostBattleInfoResponse.encode(msg);
 
 				// Send the response to the client
-				common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+				common.sendResponse(message, res, req.rawHeaders);
 			}
         })
 
@@ -117,7 +117,7 @@ export default class GhostModule extends Module {
             let message = wm.wm.protobuf.LoadStampTargetResponse.encode(msg);
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -194,7 +194,7 @@ export default class GhostModule extends Module {
             let message = wm.wm.protobuf.SearchCarsByLevelResponse.encode(msg);
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
 
 
@@ -286,7 +286,7 @@ export default class GhostModule extends Module {
 			let message = wm.wm.protobuf.LoadGhostDriveDataResponse.encode(msg);
             
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
 
 
@@ -348,7 +348,7 @@ export default class GhostModule extends Module {
             let message = wm.wm.protobuf.RegisterGhostTrailResponse.encode(msg);
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -410,7 +410,7 @@ export default class GhostModule extends Module {
             let message = wm.wm.protobuf.GhostTrail.encode(msg);
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -516,7 +516,7 @@ export default class GhostModule extends Module {
 			let message = wm.wm.protobuf.LoadPathsAndTuningsResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -535,7 +535,7 @@ export default class GhostModule extends Module {
 			let message = wmsrv.wm.protobuf.LockCrownResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
     }
 }

--- a/src/modules/ghost_ocm.ts
+++ b/src/modules/ghost_ocm.ts
@@ -378,7 +378,7 @@ export default class GhostModule extends Module {
 			let message = wm.wm.protobuf.LoadGhostCompetitionInfoResponse.encode(msg);
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -699,7 +699,7 @@ export default class GhostModule extends Module {
 			let message = wm.wm.protobuf.GhostCompetitionTarget.encode(msg);
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
     }
 }

--- a/src/modules/resource.ts
+++ b/src/modules/resource.ts
@@ -76,7 +76,7 @@ export default class ResourceModule extends Module {
             let message = wm.wm.protobuf.PlaceList.encode({places});
 
              // Send the response to the client
-             common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+             common.sendResponse(message, res, req.rawHeaders);
         })
 
         // Get Ranking data for attract screen (TA, Ghost, VS)
@@ -103,7 +103,7 @@ export default class ResourceModule extends Module {
 			let message = wmsrv.wm.protobuf.Ranking.encode({lists});
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
 
 
@@ -123,7 +123,7 @@ export default class ResourceModule extends Module {
             let message = wmsrv.wm.protobuf.CrownList.encode( {crowns} );
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
 
 
@@ -184,7 +184,7 @@ export default class ResourceModule extends Module {
 			let message = wm.wm.protobuf.FileList.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
         
@@ -206,7 +206,7 @@ export default class ResourceModule extends Module {
 			let message = wmsrv.wm.protobuf.GhostList.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
     }
 }

--- a/src/modules/startup.ts
+++ b/src/modules/startup.ts
@@ -49,7 +49,7 @@ export default class StartupModule extends Module {
             let message = wm.wm.protobuf.RegisterSystemInfoResponse.encode(msg);
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
 
 
@@ -70,7 +70,7 @@ export default class StartupModule extends Module {
             let message = wm.wm.protobuf.UpdateUserSessionResponse.encode(msg);
             
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         });
 
 
@@ -89,7 +89,7 @@ export default class StartupModule extends Module {
             let message = wm.wm.protobuf.PingResponse.encode(ping);
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
 
         
@@ -110,7 +110,7 @@ export default class StartupModule extends Module {
 			let message = wm.wm.protobuf.RegisterSystemStatsResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -135,7 +135,7 @@ export default class StartupModule extends Module {
 			let message = wm.wm.protobuf.UpdateEventModeSerialResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -156,7 +156,7 @@ export default class StartupModule extends Module {
 			let message = wm.wm.protobuf.SubmitClientLogResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
     }
 }

--- a/src/modules/terminal.ts
+++ b/src/modules/terminal.ts
@@ -36,7 +36,7 @@ export default class TerminalModule extends Module {
 			let message = wm.wm.protobuf.LoadTerminalInformationResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -91,7 +91,7 @@ export default class TerminalModule extends Module {
 			let message = wm.wm.protobuf.LoadBookmarksResponse.encode(msg);
 			
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -148,7 +148,7 @@ export default class TerminalModule extends Module {
 			let message = wm.wm.protobuf.LoadBookmarksResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -177,7 +177,7 @@ export default class TerminalModule extends Module {
 			let message = wm.wm.protobuf.LoadBookmarksResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 		
@@ -300,7 +300,7 @@ export default class TerminalModule extends Module {
 			let message = wm.wm.protobuf.CarSummary.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -360,7 +360,7 @@ export default class TerminalModule extends Module {
 			let message = wm.wm.protobuf.SaveTerminalResultResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -440,7 +440,7 @@ export default class TerminalModule extends Module {
 			let message = wm.wm.protobuf.LoadScratchInformationResponse.encode(msg);
 			
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		});
 
 
@@ -469,7 +469,7 @@ export default class TerminalModule extends Module {
 			let message = wm.wm.protobuf.TurnScratchSheetResponse.encode(msg);
 			
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -598,7 +598,7 @@ export default class TerminalModule extends Module {
 			let message = wm.wm.protobuf.SaveScratchSheetResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 		
@@ -1033,7 +1033,7 @@ export default class TerminalModule extends Module {
 			let message = wm.wm.protobuf.LoadGhostCompetitionRankingResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 		
@@ -1098,7 +1098,7 @@ export default class TerminalModule extends Module {
 			let message = wm.wm.protobuf.RegisterOpponentGhostResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -1144,7 +1144,7 @@ export default class TerminalModule extends Module {
             });
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         });
 
 
@@ -1163,7 +1163,7 @@ export default class TerminalModule extends Module {
 			let message = wmsrv.wm.protobuf.LoadUnreceivedUserItemsResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -1181,7 +1181,7 @@ export default class TerminalModule extends Module {
 			let message = wmsrv.wm.protobuf.CheckItemReceivableCarsResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 		*/
     }	

--- a/src/modules/time_attack.ts
+++ b/src/modules/time_attack.ts
@@ -60,7 +60,7 @@ export default class TimeAttackModule extends Module {
                 let message = wm.wm.protobuf.LoadTimeAttackRecordResponse.encode(msg);
 
                 // Send the response to the client
-                common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+                common.sendResponse(message, res, req.rawHeaders);
 				return;
 			}
 
@@ -83,7 +83,7 @@ export default class TimeAttackModule extends Module {
             let message = wm.wm.protobuf.LoadTimeAttackRecordResponse.encode(msg);
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
     }
 }

--- a/src/modules/users.ts
+++ b/src/modules/users.ts
@@ -68,7 +68,7 @@ export default class UserModule extends Module {
 					let message = wm.wm.protobuf.LoadUserResponse.encode(msg);
 
 					// Send the response to the client
-					common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+					common.sendResponse(message, res, req.rawHeaders);
 
 					return;
 				}
@@ -93,7 +93,7 @@ export default class UserModule extends Module {
 						let message = wm.wm.protobuf.LoadUserResponse.encode(msg);
 
 						// Send the response to the client
-						common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+						common.sendResponse(message, res, req.rawHeaders);
 
 						return;
 					}
@@ -199,7 +199,7 @@ export default class UserModule extends Module {
 				let message = wm.wm.protobuf.LoadUserResponse.encode(msg);
 
 				// Send the response to the client
-				common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+				common.sendResponse(message, res, req.rawHeaders);
 
 				return;
 			}
@@ -587,7 +587,7 @@ export default class UserModule extends Module {
 			let message = wm.wm.protobuf.LoadUserResponse.encode(msg);
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
 
 
@@ -643,7 +643,7 @@ export default class UserModule extends Module {
 			let message = wm.wm.protobuf.CreateUserResponse.encode(msg);
 
             // Send response to client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		});
 
 
@@ -694,7 +694,7 @@ export default class UserModule extends Module {
             let message = wm.wm.protobuf.LoadDriveInformationResponse.encode(msg);
             
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
 
         
@@ -710,7 +710,7 @@ export default class UserModule extends Module {
             let message = wm.wm.protobuf.UpdateUserSessionResponse.encode(msg);
 
             // Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         })
 
 
@@ -730,7 +730,7 @@ export default class UserModule extends Module {
 			let message = wmsrv.wm.protobuf.StartTransferResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         });
 
 
@@ -749,7 +749,7 @@ export default class UserModule extends Module {
 			let message = wmsrv.wm.protobuf.GrantCarRightResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         });
 
 
@@ -768,7 +768,7 @@ export default class UserModule extends Module {
 			let message = wmsrv.wm.protobuf.AskAccessCodeResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         });
 
         
@@ -787,7 +787,7 @@ export default class UserModule extends Module {
 			let message = wmsrv.wm.protobuf.ParticipateInInviteFriendCampaignResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
         });
 
 
@@ -805,7 +805,7 @@ export default class UserModule extends Module {
 			let message = wmsrv.wm.protobuf.ConsumeUserItemResponse.encode(msg);
 
 			// Send the response to the client
-            common.sendResponse(message, res, req.rawHeaders[5], req.rawHeaders[7]);
+            common.sendResponse(message, res, req.rawHeaders);
 		})
         */
     }

--- a/src/modules/util/common.ts
+++ b/src/modules/util/common.ts
@@ -3,53 +3,97 @@ import { Writer } from "protobufjs";
 import { Config } from "../../config";
 import Long from "long";
 
+// getProtobufRevision: Number
+// Given the headers from a request, filters
+// the 'application/x-protobuf' property from the
+// request and returns the value. If not found, 
+// returns null.
+function getProtobufRevision(headers: string[]) {
+
+    try {
+        // Find protobuf revision headers
+        const filtered = headers.filter(
+            x => x.includes('application/x-protobuf')
+        );
+
+        // At least one header is found
+        if (filtered.length > 0) {
+            // These should be all the same, just take the first one
+            const header = filtered.pop();
+
+            // Header is not null
+            if (header) {
+                // Header includes a semicolon
+                if (header.includes('=')) {
+                    // Retrieves the protobuf revision from the header, 
+                    // strips any trailing whitespace and converts to int
+                    const value = Number(header.split('=')[1].trimEnd());
+
+                    // Return the revision
+                    return value;
+                }
+                else // No semicolon
+                {
+                    throw Error(`No revision found in protobuf header!`);
+                }
+            }
+            else {
+                throw Error(`Protobuf header is not defined!`);
+            }
+        }
+        else // No headers found
+        {
+            throw Error("Protobuf revision not found!");
+        }
+    }
+    catch (e) // Failed to get protobuf revision
+    {
+        writeLog(`Failed to get protobuf revision! ${String(e)}`);
+
+        // No protobuf revision
+        return null;
+    }
+}
 
 // sendResponse(message, res): Void
 // Sends the server response to the client
-export function sendResponse(message: Writer, res: Response, rawHeaders: string, rawHeaders2: string)
-{
-    // Get the end of the message
-    let end = message.finish();
+export function sendResponse(message: Writer, res: Response, headers: string[]) {
+    try {
 
-    // Built the response data
-    let r = res
-        .header('Server', 'v388 wangan')
-        .header('Content-Type', 'application/x-protobuf; revision=8053')
-        .header('Content-Length', end.length.toString())
-        .status(200);
+        // Get config
+        const config = Config.getConfig();
 
-    // Revision Check
-    let revisionCheck = Config.getConfig().gameOptions.revisionCheck || 1;
+        // Get the end of the message
+        let end = message.finish();
 
-    // Revision Check is enabled
-    if(revisionCheck === 1)
-    {
-        // Get the Revision
-        let getProtobufRev;
-        if(rawHeaders.includes('application/x-protobuf')) // application/x-protobuf; revision=number_here
-        {
-            getProtobufRev = rawHeaders.split('; ');
+        // Built the response data
+        let r = res
+            .header('Server', 'v388 wangan')
+            .header('Content-Type', 'application/x-protobuf; revision=8053')
+            .header('Content-Length', end.length.toString())
+            .status(200);
+
+        // If revision check is enabled
+        if (config.gameOptions.revisionCheck) {
+
+            // Get the protobuf revision from the headers
+            let revision = getProtobufRevision(headers);
+
+            // Revision does not match
+            if (revision !== 8053) {
+                throw Error(`Protobuf revision does not match!`);
+            }
         }
-        else
-        {
-            getProtobufRev = rawHeaders2.split('; ');
-        }
-        
-        let protobufRev = getProtobufRev[1].split('='); // array 0 = content type, array 1 = protobuf revision
 
-        // Connect to the server if the Revision is match
-        if(protobufRev[1] === "8053")
-        {
-            // Send the response to the client
-            r.send(Buffer.from(end));
-        }
-        // else{} Prevent connecting to the server
-    }
-    // Just send it
-    else
-    {
         // Send the response to the client
         r.send(Buffer.from(end));
+    }
+    catch (e) // Failed to send response
+    {
+        writeLog(`Failed to send response: ${String(e)}`);
+
+        // Internal Server Error
+        res.sendStatus(500);
     }
 }
 
@@ -57,14 +101,12 @@ export function sendResponse(message: Writer, res: Response, rawHeaders: string,
 // getBigIntFromLong(n: Long): BigInt
 // Given a Long data object, converts 
 // it into a BigInt and returns it.
-export function getBigIntFromLong(n: Long)
-{
+export function getBigIntFromLong(n: Long) {
     // Create the default value
     let bigInt = BigInt(0);
 
     // If 'n' is a long data type
-    if (n instanceof Long) 
-    {
+    if (n instanceof Long) {
         // Perform the  bit-wise operations
         bigInt = bigInt | BigInt(n.high);
         bigInt = bigInt << BigInt(32);
@@ -77,30 +119,26 @@ export function getBigIntFromLong(n: Long)
 
 
 // Undefined Input Sanitization
-export function sanitizeInput(value: any)
-{
+export function sanitizeInput(value: any) {
     return (value == null || value == undefined) ? undefined : value;
 }
 
 
 // Undefined and Zero Input Sanitization
-export function sanitizeInputNotZero(value: any)
-{
+export function sanitizeInputNotZero(value: any) {
     return (value !== null && value !== undefined && value !== 0) ? value : undefined;
 }
 
 
 // Get Time Stamp
-export function getTimeStamp(date: Date = new Date())
-{
+export function getTimeStamp(date: Date = new Date()) {
     // Return a timestamp string for the current / provided time
     return String("[" + date.toLocaleString() + "]");
 }
 
 
 // Write Log
-export async function writeLog(message: string)
-{
+export async function writeLog(message: string) {
     try {
         // Get the current timestamp
         const timestamp: string = getTimeStamp();


### PR DESCRIPTION
Hi all, long time no see

I had some issues where the protobuf revision headers were not sent in the correct indexes, which was causing the server to crash. So, I've added error handling to sendResponse, and the program now performs a filter to find the protobuf revision headers rather than hard-coding the indexes.

The code for retrieving the protobuf revision from the request headers has now been moved to its own common library function `getProtobufRevision`, which takes the raw headers as a string array as an argument. As a result of this, `sendResponse` has also been modified to take the headers argument as an array rather than headers[2] and headers[5] seperately. All instances of this function call have been replaced to fit the new usage.

Please feel free to let me know if you have any questions

Cheers,
Scrubbs