### PR TITLE
Github Actions and Github Container Registry implementation

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -2,7 +2,7 @@ name: Publish container
 
 on:
   push:
-    branches: [dockerized-node22]
+    branches: [master]
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,76 @@
+name: Publish container
+
+on:
+  push:
+    branches: [dockerized-node22]
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        build-targets:
+          - label: ubuntu-latest
+            arch: amd64
+            manifest-name: x64
+          - label: ubuntu-24.04-arm
+            arch: arm64
+            manifest-name: arm64
+    permissions:
+      contents: read
+      packages: write
+    name: Build Container for ${{ matrix.build-targets.manifest-name }}
+    runs-on: ${{ matrix.build-targets.label }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        run: |
+          # First, lowercase-ify owner
+          export owner=${{ github.repository_owner }}
+          export owner=${owner,,}
+          docker buildx build \
+            --platform linux/${{ matrix.build-targets.arch }} \
+            --push \
+            -t "ghcr.io/${owner}/bayshore:${{ matrix.build-targets.manifest-name }}-${{ github.sha }}" \
+            -t "ghcr.io/${owner}/bayshore:${{ matrix.build-targets.manifest-name }}-latest" \
+            --provenance false \
+            .
+  merge-container:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge images
+        run: |
+          # First, lowercase-ify owner
+          export owner=${{ github.repository_owner }}
+          export owner=${owner,,}
+          docker manifest create "ghcr.io/${owner}/bayshore:latest" \
+            --amend "ghcr.io/${owner}/bayshore:arm64-${{ github.sha }}" \
+            --amend "ghcr.io/${owner}/bayshore:x64-${{ github.sha }}"
+          docker manifest push "ghcr.io/${owner}/bayshore:latest"
+
+          docker manifest create "ghcr.io/${owner}/bayshore:${{ github.sha }}" \
+            --amend "ghcr.io/${owner}/bayshore:arm64-${{ github.sha }}" \
+            --amend "ghcr.io/${owner}/bayshore:x64-${{ github.sha }}"
+          docker manifest push "ghcr.io/${owner}/bayshore:${{ github.sha }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:18-alpine AS base
 FROM base AS builder
 
 WORKDIR /server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS base
+FROM node:22-alpine AS base
 FROM base AS builder
 
 WORKDIR /server
@@ -40,7 +40,9 @@ RUN npm ci && \
 COPY --from=builder /server/dist /home/node/dist
 
 # Copy game configuration file and certificate
-COPY server_wangan.key server_wangan.crt config.json ./
+COPY server_wangan.key server_wangan.crt ./
+
+VOLUME [ "/home/node/config.json" ]
 
 # This ensures that the final dist files are readonly to this node user when running the application.
 USER node


### PR DESCRIPTION
Pre-requisite: 
1. Enable public packages for containers: [gh packages settings](https://github.com/organizations/ProjectAsakura/settings/packages)
simply tick the checkbox in public packages and save.

2. in the ProjectAsakura/Bayshore, change the [gh actions settings](https://github.com/ProjectAsakura/Bayshore/settings/actions)
Under Workflow permissions, change it to Read repository contents <ins>and packages permissions</ins>.

3. Review, suggest code changes if necessary, approve this pr :)

Then it should be mergable.

This pr will build and push bayshore in 2 architectures arm64 and x64.

I removed the copy for config.json into the container since this should be a generic image.